### PR TITLE
add account owner to IBAN

### DIFF
--- a/en/contribute.md
+++ b/en/contribute.md
@@ -28,7 +28,7 @@ If you want to talk with us or other users you may:
 
 Delta Chat development costs **money**. Your donation will support future improvements directly.
 
-- IBAN DE86100777770428658900, BIC NORSDE51XXX
+- IBAN DE86100777770428658900, Account owner (please always specify): Björn Petersen, BIC NORSDE51XXX
 - PayPal or credit card: [paypal.me/deltachat](https://paypal.me/deltachat/20)
 - Send bitcoins to [18e3zwis2raitdZVhEhHHT7xG6oXsZte9L](bitcoin:18e3zwis2raitdZVhEhHHT7xG6oXsZte9L)
 


### PR DESCRIPTION
just got some post, the bank won't accept mismatching account owners in the near future.