### PR TITLE
make multi-line headlines look nicer

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -123,7 +123,7 @@ body {
 #content ul li { list-style: disc outside; margin: 0.5em 0.2em; padding-left: 0.5em; }
 ol li { list-style: decimal; margin: 0.5em 0.2em; padding-left: 0.5em; }
 
-h1 { font-weight: normal; font-size: 24px; letter-spacing: 2px; color: #000; }
+h1 { font-weight: normal; font-size: 24px; letter-spacing: 1px; line-height: 1.4em; color: #000; }
 h2 { font-weight: bold; font-size: 16px; letter-spacing: 1px; color: #159957; }
 
 a, a:visited {


### PR DESCRIPTION
the line-height of h1-elements spanning multiple-lines was a bit too small. and the spacing between characters was a bit too much, esp. in combination with multiple-lines.

this pr tries to mitigate both.