### PR TITLE
improve 'own server' wording

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -10,7 +10,7 @@ layout: default-en
 **Delta Chat is like Telegram or Whatsapp but without the tracking or central control.**
 Check out our [GDPR compliancy statement](gdpr).
 
-**Delta Chat has no own servers** but uses the most massive and diverse open messaging 
+**Delta Chat doesn't have their own servers** but uses the most massive and diverse open messaging 
 system ever: the existing e-mail server network.
 
 **Chat with anyone if you know their e-mail address, no need for them to install DeltaChat!** 


### PR DESCRIPTION
the "has no own server" wording seems to be german, cmp https://news.ycombinator.com/item?id=19216827
(fun-fact is that the webserver says there is no server, however, i think the intention is clear to most readers) 

i do not have an idea about this. maybe someone with good english knowledge or a native speaker can check?

cc @Valodim