### PR TITLE
index.md: hint and mention email account login

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -3,7 +3,7 @@ title: The messenger
 layout: default-en
 ---
 
-# Head back to the future with Email-Chat!
+# Back to the future with Email-Chat!
 
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 

--- a/en/index.md
+++ b/en/index.md
@@ -3,7 +3,7 @@ title: The messenger
 layout: default-en
 ---
 
-# Back to the future with Email-Chat!
+# Back to the future, with Email-Chat!
 
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 

--- a/en/index.md
+++ b/en/index.md
@@ -8,10 +8,10 @@ layout: default-en
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 
 **Delta Chat is as easy-to-use as Telegram or Whatsapp, but without the tracking or central control.**
-Check out our [GDPR compliancy statement](gdpr).
+Check out our [GDPR data protection compliancy statement](gdpr).
 
 **Chat with anyone if you know their e-mail address, even if they are not (yet) using Delta Chat!** 
-All you need is a standard e-mail account login.
+All you need is your own standard e-mail account login.
 
 **Delta Chat doesn't make you use their own servers**, it uses the most massive and diverse, federated open messaging 
 system ever: the existing e-mail server network.

--- a/en/index.md
+++ b/en/index.md
@@ -3,18 +3,18 @@ title: The messenger
 layout: default-en
 ---
 
-# Chat over e-mail and head back to the future with us!
+# Head back to the future with Email-Chat!
 
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 
 **Delta Chat is like Telegram or Whatsapp but without the tracking or central control.**
 Check out our [GDPR compliancy statement](gdpr).
 
+**Chat with anyone if you know their e-mail address, no need for them to install DeltaChat!** 
+All you need is a standard e-mail account login.
+
 **Delta Chat doesn't have their own servers** but uses the most massive and diverse open messaging 
 system ever: the existing e-mail server network.
-
-**Chat with anyone if you know their e-mail address, no need for them to install DeltaChat!** 
-All you need is a standard e-mail account.
 
 
 # Screenshots Android, Desktop and iOS 

--- a/en/index.md
+++ b/en/index.md
@@ -7,13 +7,13 @@ layout: default-en
 
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 
-**Delta Chat is like Telegram or Whatsapp but without the tracking or central control.**
+**Delta Chat is easy to use as Telegram or Whatsapp but without the tracking or central control.**
 Check out our [GDPR compliancy statement](gdpr).
 
-**Chat with anyone if you know their e-mail address, no need for them to install DeltaChat!** 
+**Chat with anyone if you know their e-mail address, even they are not (yet) using Delta Chat!** 
 All you need is a standard e-mail account login.
 
-**Delta Chat doesn't have their own servers** but uses the most massive and diverse open messaging 
+**Delta Chat doesn't make you use their own servers**, it uses the most massive and diverse, federated open messaging 
 system ever: the existing e-mail server network.
 
 

--- a/en/index.md
+++ b/en/index.md
@@ -14,7 +14,7 @@ Check out our [GDPR data protection compliancy statement](gdpr).
 All you need is your own standard e-mail account login.
 
 **Delta Chat doesn't make you use its own servers**, it uses the most massive and diverse, federated open messaging 
-system ever: the existing e-mail server network.
+system ever: the existing e-mail server network. It only creates a separate subfolder on your e-mail account.
 
 
 # Screenshots Android, Desktop and iOS 

--- a/en/index.md
+++ b/en/index.md
@@ -7,13 +7,13 @@ layout: default-en
 
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 
-**Delta Chat is as easy-to-use as Telegram or Whatsapp, but without the tracking or central control.**
+**The Delta Chat app is as easy-to-use as Telegram or Whatsapp, but without any tracking or central control.**
 Check out our [GDPR data protection compliancy statement](gdpr).
 
 **Chat with anyone if you know their e-mail address, even if they are not (yet) using Delta Chat!** 
 All you need is your own standard e-mail account login.
 
-**Delta Chat doesn't make you use their own servers**, it uses the most massive and diverse, federated open messaging 
+**Delta Chat doesn't make you use its own servers**, it uses the most massive and diverse, federated open messaging 
 system ever: the existing e-mail server network.
 
 

--- a/en/index.md
+++ b/en/index.md
@@ -7,10 +7,10 @@ layout: default-en
 
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 
-**Delta Chat is easy to use as Telegram or Whatsapp but without the tracking or central control.**
+**Delta Chat is easy to use as Telegram or Whatsapp, but without the tracking or central control.**
 Check out our [GDPR compliancy statement](gdpr).
 
-**Chat with anyone if you know their e-mail address, even they are not (yet) using Delta Chat!** 
+**Chat with anyone if you know their e-mail address, even if they are not (yet) using Delta Chat!** 
 All you need is a standard e-mail account login.
 
 **Delta Chat doesn't make you use their own servers**, it uses the most massive and diverse, federated open messaging 

--- a/en/index.md
+++ b/en/index.md
@@ -7,7 +7,7 @@ layout: default-en
 
 <img src="../assets/logos/delta-chat.svg" width="160" style="float: left; margin: 20px;" />
 
-**Delta Chat is easy to use as Telegram or Whatsapp, but without the tracking or central control.**
+**Delta Chat is as easy-to-use as Telegram or Whatsapp, but without the tracking or central control.**
 Check out our [GDPR compliancy statement](gdpr).
 
 **Chat with anyone if you know their e-mail address, even if they are not (yet) using Delta Chat!** 


### PR DESCRIPTION
Background:
"First contact" potential new users are often surprised and not prepared to provide their email account credentials for the initial setup. Simply explicitly mentioning their email account login in any information that is presented at first (and in the beginning) should make them aware.

Changes:
Improved context hints and and explicit mention of the required email account login (earlier): In the title and already as second bullet point, to make new user contacts already more aware of this in order to be prepared for the installation (account setup).

I think the header change may be discussed separately, the changes in the paragraphs are worth it on its own.

A specific use-case example is be the invitation of old messenger-contact (budies) that need to get a brief picture about what is involved by using deltachat, and visit the homepage. 
(Discussion at: https://support.delta.chat/t/lets-switch-to-a-new-messenger/334)