### PR TITLE
adapt "sed" to work on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,9 @@ Directory structure
 
 - `/en` - Contains the source language files in Markdown. Can be edited directly.
 
-- `/de`, `/es`, `fr` … - Contain the translated files; 
-  translation is done through .po files that are translated using Transifex, see above. 
-  You must not edit translated files directly here, 
-  but you can add additional files that are unique to the language.
+- `/de`, `/es`, `fr` … - Contain the translated files, use Transifex to edit them;
+  you **MUST NOT** edit any file in these directories,
+  they will be overwritten with the next pull from Transifex.
 
 - `/_layouts` - This directory contains a default layout template 
   for each language (the layout is referenced in Markdown using _layout: name_)

--- a/tools/t-dance.sh
+++ b/tools/t-dance.sh
@@ -56,11 +56,11 @@ create_markdown_files() {
 	echo "Creating markdown files from the translated po-files ..."
 	for sfile in ${sfiles[@]}; do
 		for tlang in ${tlangs[@]}; do
+			echo "processing ${tlang:0:2}/${sfile}.po"
 			pofile="../${tlang:0:2}/${sfile}.po"
 			mdfile="../${tlang:0:2}/${sfile}.md"
 			po2txt --progress=none --template="../en/${sfile}.md" $pofile $mdfile
-			sed -i "s/lang: \S*/lang: ${tlang:0:2}/" $mdfile # correct used layout
-			sed -i "0,/^$/ s/^$/\n\n\n<!-- GENERATED FILE -- DO NOT EDIT -->\n\n\n/" $mdfile # add a comment in the first empty line (with `0,/^$/` you select all lines until the re matches)
+			sed -i "" "s/lang: [a-z][a-z]/lang: ${tlang:0:2}/" $mdfile # correct used layout - for some reasons, [a-z]{2,} does not work on sed-mac
 		done
 	done	
 }


### PR DESCRIPTION
freebsd seems to be different from unix here.
i did not figure out how to adapt the statement
that adds the "GENERATED" hint to the content.
however, comments in markdown are not really standard anyway,
so i decided to make the hint in the README clearer.

in general, i think the t-dance script
should be replaced by a python script as some point -
but, for now, it works again ;)