### PR TITLE
Fix the link to Autocrypt-enabled e-mail apps

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -442,7 +442,7 @@ Otherwise, deleting messages or multi-device setups might not work properly.
   encrypted, though. The End-to-End encryption those providers offer is only
   working inside their platforms, and not compatible with anyone outside.
 - Delta Chat can e2e-encrypt through any e-mail provider with any
-  [https://autocrypt.org/dev-status.html](Autocrypt-enabled e-mail app).
+  [Autocrypt-enabled e-mail app](https://autocrypt.org/dev-status.html).
 
 
 ### I'm interested in the technical details. Can you tell me more?


### PR DESCRIPTION
The Markdown link syntax was the wrong way around.