### PR TITLE
revert "desktop -> 1.0.0" because of encryption bug

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -1,6 +1,6 @@
 {% assign txEn = site.data.lang['en']['en'] %}
 {% assign tx = site.data.lang[page.lang][page.lang] %}
-{% assign VERSION_DESKTOP = "1.0.0" %}
+{% assign VERSION_DESKTOP = "0.999.1" %}
 
 <div class="download-content">
     <div id="recommendation-section" hidden>


### PR DESCRIPTION
this reverts commit 1a98333941cc03ef0ff385259ec1b933e8c33393.

desktop 1.0.0 uses core25 that has an [encryption bug](https://github.com/deltachat/deltachat-core-rust/issues/1313) related to the new ecc keys. i think it is better to no offer this version for download currently (android+ios version using core25 are also not really released yet)