### PR TITLE
streamline preview builds

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -40,8 +40,6 @@
             </div>
             <div class="descr">
                 <a href="https://github.com/deltachat/deltachat-ios">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
-                &ndash;
-                <a href="https://testflight.apple.com/join/uEMc1NxS">{%if tx.download.beta_on != ""%}{{ tx.download.beta_on }}{%else%}{{ txEn.download.beta_on }}{%endif%} Testflight</a>
             </div>
         </div>
         <div class="box" id="macos">

--- a/en/download.md
+++ b/en/download.md
@@ -20,7 +20,7 @@ downloads: true
 ## Preview Builds
 
 * [Desktop Previews](https://download.delta.chat/desktop/preview/): Pending changes for the desktop clients
-* [Android Nightly](https://download.delta.chat/android/nightly/): Build last night with the most recent core
+* [Android Nightly](https://download.delta.chat/android/nightly/): Built last night with the most recent core
 * [iOS Testflight](https://testflight.apple.com/join/uEMc1NxS): May contain not yet officially released iOS versions
 
 Preview builds may come with new bugs and should not be used productive.

--- a/en/download.md
+++ b/en/download.md
@@ -17,5 +17,8 @@ downloads: true
 * [FAQ multiclient](help#multiclient): How to synchronize Desktop with another Delta Chat app.
 * [Verify Downloads](verify-downloads): Verify data integrity of downloads
 
-## Preview Builds:
-* [Desktop](https://download.delta.chat/desktop/preview/)
+## Preview Builds
+
+* [Desktop Previews](https://download.delta.chat/desktop/preview/)
+* [Android Nightly](https://download.delta.chat/android/nightly/)
+* [iOS Testflight](https://testflight.apple.com/join/uEMc1NxS)

--- a/en/download.md
+++ b/en/download.md
@@ -19,6 +19,8 @@ downloads: true
 
 ## Preview Builds
 
-* [Desktop Previews](https://download.delta.chat/desktop/preview/)
-* [Android Nightly](https://download.delta.chat/android/nightly/)
-* [iOS Testflight](https://testflight.apple.com/join/uEMc1NxS)
+* [Desktop Previews](https://download.delta.chat/desktop/preview/): Pending changes for the desktop clients
+* [Android Nightly](https://download.delta.chat/android/nightly/): Build last night with the most recent core
+* [iOS Testflight](https://testflight.apple.com/join/uEMc1NxS): May contain not yet officially released iOS versions
+
+Preview builds may come with new bugs and should not be used productive.


### PR DESCRIPTION
this adds a link to android-nightly
and moves the ios-testflight link to the same section.