### PR TITLE
add information about minimal requirements

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -11,6 +11,14 @@ downloads: true
 * [iOS](https://github.com/deltachat/deltachat-ios/blob/master/CHANGELOG.md)
 * [Core](https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md)
 
+The desktop versions do not require Delta Chat to be installed on a phone.
+
+Minimal requirements:
+Android 4.1 Jelly Bean
+or iOS 11, iPhone 5s or iPad 5/Air/Mini
+or Windows 7, macOS 10.10 Yosemite, Ubuntu 12.04, Fedora 21 or Debian 8
+or compatible systems.
+
 ## Links
 
 * [Provider Database](https://providers.delta.chat/): Does my Provider work with Delta Chat?


### PR DESCRIPTION
this pr adds a very short, condensed line about the minimal requirements across all versions.

i think the "Changelog" section is the closest match and not that wrong,
adding it directly below the boxes looks bad
and i do not want to add an extra headline,
there is no need to make this too much outstanding, ppl will find it.
for the same reason, i do not want to add it directly to the boxes.

wrt desktop: i copied the information from: https://www.electronjs.org/docs/tutorial/support 