### PR TITLE
alternative blog preview

### DIFF
--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -1,17 +1,13 @@
 {% assign index = 0 %}
 {% for post in site.posts %}
 {% assign index = index | plus:1 %}
-{% if post.image and index <= 10 %}
+{% if post.image and index <= 12 %}
 <div class="post-box">
   <a href="{{ site.baseurl }}{{ post.url }}">
     <div class="featured-image">
       <img src="{{ post.image }}" />
     </div>
-{% else %}
-<div>
-  <a href="{{ site.baseurl }}{{ post.url }}">
-{% endif %}
-  <h2>{{ post.title }}</h2>
+    <h2>{{ post.title }}</h2>
   </a>
   <p>
     <em>{{ post.date | date: "%B %d, %Y" }}</em> -
@@ -19,4 +15,15 @@
     <a href="{{ site.baseurl }}{{ post.url }}">Read on...</a>
   </p>
 </div>
+{% else %}
+<div>
+  {% if index == 13 %}
+  <h2>Older posts</h2>
+  {% endif %}
+  <p>
+    <em>{{ post.date | date: "%B %Y" }}</em> -
+    <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+  </p>
+</div>
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
due to a lack of a paging functionality
(which i personally do not miss ;)
and to keep the overall page size small,
we did not add an image for the 10th oldest blob post.

this results in some "text desert"
that is not really nice and makes the page
a bit unclear when scolling down.
too many information :)

this commit changes that by just adding the clickable title
for older posts.
moreover, the "new posts" are increased to 12 (so, roughly a year ;)

by the decreased amount of text,
the page is now smaller, both, in size and visually.
also, this hides the fact that old blog posts are not always so nice
(eg. they do not have a preview image, so paging would not be nice)

i find the blog much nicer this way,
see preview.