### PR TITLE
better social media previews

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,8 +8,14 @@
 <title>{{ page.title }} - Delta Chat</title>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
-<meta name="description" content="{%if tx.meta.description != ""%}{{ tx.meta.description }}{%else%}{{ txEn.meta.description }}{%endif%}" />
+<meta name="description" content="{{ content | strip_html | xml_escape | truncate: 200 }}" />
 <meta name="keywords" content="{%if tx.meta.keywords != ""%}{{ tx.meta.keywords }}{%else%}{{ txEn.meta.keywords }}{%endif%}" />
+
+<meta property="og:title" content="Delta Chat: {{ page.title }}">
+<meta property="og:description" content="{{ content | strip_html | xml_escape | truncate: 200 }}">
+<meta property="og:image" content="{%if page.image%}{{ page.image }}{%else%}https://delta.chat/assets/home/intro1.png{%endif%}">
+<meta property="og:url" content="https://delta.chat{{ page.url }}">
+<meta name="twitter:card" content="summary">
 
 <link rel="stylesheet" href="../assets/css/styles.css" type="text/css" />
 <link rel="alternate" href="https://delta.chat/feed.xml" type="application/atom+xml" title="{%if tx.rss_news_title != ""%}{{ tx.rss_news_title }}{%else%}{{ txEn.rss_news_title }}{%endif%}" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,12 @@
 <title>{{ page.title }} - Delta Chat</title>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
-<meta name="description" content="{{ content | strip_html | xml_escape | truncate: 200 }}" />
+<meta name="description" content="{{ content | strip_html | xml_escape | normalize_whitespace | truncate: 200 }}" />
 <meta name="keywords" content="{%if tx.meta.keywords != ""%}{{ tx.meta.keywords }}{%else%}{{ txEn.meta.keywords }}{%endif%}" />
 
 <meta property="og:title" content="Delta Chat: {{ page.title }}">
-<meta property="og:description" content="{{ content | strip_html | xml_escape | truncate: 200 }}">
-<meta property="og:image" content="{%if page.image%}{{ page.image }}{%else%}https://delta.chat/assets/home/intro1.png{%endif%}">
+<meta property="og:description" content="{{ content | strip_html | xml_escape | normalize_whitespace | truncate: 200 }}">
+<meta property="og:image" content="{%if page.image%}{{ page.image | replace:'../','https://delta.chat/' }}{%else%}https://delta.chat/assets/home/intro1.png{%endif%}">
 <meta property="og:url" content="https://delta.chat{{ page.url }}">
 <meta name="twitter:card" content="summary">
 


### PR DESCRIPTION
this pr add basic meta-tags that are used by typical social media platforms to create previews.

i used https://medium.com/@dinojoaocosta/how-to-make-twitter-preview-your-website-links-5b20db98ac4f and  https://medium.com/@dinojoaocosta/how-to-make-twitter-preview-your-website-links-5b20db98ac4f for inspiration.

once the preview is there, that can be tested out at https://cards-dev.twitter.com/validator

todo:

- [x] `og:image` should better be absolute (twitter does not download relative urls)
- [x] there are too many linebreaks left by `strip_html`

closes #350