### PR TITLE
split first paragraph of ios-blogpost

### DIFF
--- a/_posts/2021-02-04-ios-is-catching-up.md
+++ b/_posts/2021-02-04-ios-is-catching-up.md
@@ -5,10 +5,11 @@ image: ../assets/blog/2021-02-04-context-menu-small.jpg
 ---
 
 _Delta Chat iOS_ is available
-[since about a year now](2020-01-09-iOS-appstore-release) 🎉 —  
+[since about a year now](2020-01-09-iOS-appstore-release) 🎉 —
 while being nicely usable and working,
 compared to the more mature Android and Desktop versions,
 some UI-features were just missing from our iOS app.
+
 Note that all platforms share the same,
 stable [Rust-core](https://github.com/deltachat/deltachat-core-rust) so you can expect the same core functionality and stability that our longer evolving Android and Desktop apps enjoy.
 


### PR DESCRIPTION
the first paragraph is shown in the blog overview
and is a bit long there, also the "Note ..."
sentence does not make much sense in the overview.

with this change, the "Read on..." link will appear one sentence before,
the remaining first paragraph has a reasonable length,
similar to all the other posts then.