### PR TITLE
fix empty-string-comparison and avoid empty <h1> tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,7 @@
 <p class="blogdate">{{ page.date | date: "%B %d, %Y" }} {% if page.author %}by {{ page.author }}{% endif %}</p>
 {% endif %}
 
-{% if page.header != blank %}
+{% if page.header != nil and page.header != "" %}
     <h1>{{page.header}}</h1>
 {% endif %}
 


### PR DESCRIPTION
came over that via https://github.com/Shopify/liquid/issues/223#issuecomment-20881188 - checking for an empty string seems to be a hard thing in jekyll :) not sure, if the `!= blank`thing has ever worked (though also recommended in the link above)