### PR TITLE
add fr to local help generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,4 +30,4 @@ plugins:
   - jekyll-sitemap
 
 # the tools directory contains cached files downloaded from transifex, ignore it
-exclude: ["tools"]
+exclude: ["tools", "venv"]

--- a/tools/create-local-help.py
+++ b/tools/create-local-help.py
@@ -79,6 +79,7 @@ def generate_help(srcdir, destdir, add_top_links=False):
     generate_lang(srcdir, destdir, "de", add_top_links)
     generate_lang(srcdir, destdir, "en", add_top_links)
     generate_lang(srcdir, destdir, "es", add_top_links)
+    generate_lang(srcdir, destdir, "fr", add_top_links)
     generate_lang(srcdir, destdir, "it", add_top_links)
     generate_lang(srcdir, destdir, "nl", add_top_links)
     generate_lang(srcdir, destdir, "ru", add_top_links)


### PR DESCRIPTION
and tell jekyll to ignore the optionional `venv` folder