### PR TITLE
add link to desktop troubleshooting

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -24,6 +24,7 @@ or compatible systems.
 * [Provider Database](https://providers.delta.chat/): Does my Provider work with Delta Chat?
 * [FAQ multiclient](help#multiclient): How to synchronize Desktop with another Delta Chat app.
 * [Verify Downloads](verify-downloads): Verify data integrity of downloads
+* [Desktop Installation Troubleshooting](https://github.com/deltachat/deltachat-desktop/blob/master/docs/TROUBLESHOOTING.md): Solutions for common desktop installation problems
 
 ## Preview Builds
 


### PR DESCRIPTION
add link to https://github.com/deltachat/deltachat-desktop/blob/master/docs/TROUBLESHOOTING.md, a page describing solutions for common installation problems.

the issue: https://github.com/deltachat/deltachat-desktop/issues/1590

maybe the wording can be improved