### PR TITLE
unify changelog urls

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -7,7 +7,7 @@ downloads: true
 ## Changelogs
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)
-* [Android]({% include changelog-url %})
+* [Android](https://github.com/deltachat/deltachat-android/blob/master/CHANGELOG.md)
 * [iOS](https://github.com/deltachat/deltachat-ios/blob/master/CHANGELOG.md)
 * [Core](https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md)
 


### PR DESCRIPTION
core/desktop/ios point to the normal github repo
that shows the changelog rich formatted, including github navigation.

android point to the raw, unformatted textfile.

boths may have advantages and disadvantages,
however, i do not know of reasons to mix the approaches.

so, this pr changes android to do the same as the other repos.

(the include file should stay as is until translations are done
and the include file is not used anywhere)