### PR TITLE
remove remark wrt status not available on ios

### DIFF
--- a/_posts/2021-05-05-email-compat.md
+++ b/_posts/2021-05-05-email-compat.md
@@ -74,7 +74,7 @@ some other highlights are:
 - Due to more messages overall, we **speedup global search**
 
 - you can see the **status** (the footer) of each contact
-  in the contact's profile (the feature is available on Android and Desktop, iOS will follow)
+  in the contact's profile
 
 
 ## How it works


### PR DESCRIPTION
ios status was added in added in 1.20.5 which was [released just now](https://github.com/deltachat/deltachat-ios/blob/master/CHANGELOG.md), together with some other bugfixes.