### PR TITLE
fix weird breaking in mobile GDPR-blog-layout

### DIFF
--- a/_posts/2021-11-10-blog-GDPR.md
+++ b/_posts/2021-11-10-blog-GDPR.md
@@ -4,7 +4,9 @@ author: jette, treefit, missytake and holga
 image: ../assets/blog/fabian-schmieder.jpeg
 ---
 
-The Delta Chat privacy policy situation just got even better! We appointed Prof. Dr. Fabian Schmieder, professor for data protection and media law of the [University of Applied Sciences and Arts Hanover](https://im.f3.hs-hannover.de/en_us/studium/personen/prof-dr-fabian-schmieder/) and coauthor of the standard work [Betrieblicher Datenschutz (Operational data protection)](https://www.beck-shop.de/forgo-helfrich-schneider-betrieblicher-datenschutz/product/24093138), who is now our data protection officer. He has been helping us for a long time and is not only a great advisor but also a brilliant pianist!:) <img src="../assets/blog/fabian-schmieder.jpeg" width="250" style="float: right; clear:both; margin-left:.1em; margin-bottom:.2em;" alt="Delta Chat DPO Fabian Schmieder" />
+The Delta Chat privacy policy situation just got even better! We appointed Prof. Dr. Fabian Schmieder, professor for data protection and media law of the [University of Applied Sciences and Arts Hanover](https://im.f3.hs-hannover.de/en_us/studium/personen/prof-dr-fabian-schmieder/) and coauthor of the standard work [Betrieblicher Datenschutz (Operational data protection)](https://www.beck-shop.de/forgo-helfrich-schneider-betrieblicher-datenschutz/product/24093138), who is now our data protection officer. He has been helping us for a long time and is not only a great advisor but also a brilliant pianist!:)
+
+<img src="../assets/blog/fabian-schmieder.jpeg" style="width:300px; float:right; clear:both; margin-left:.5em; margin-bottom:.2em;" alt="Delta Chat DPO Fabian Schmieder" />
 
 Jointly we worked with his colleague Kai Korte from [LexICT](https://lexict.de) to professionalize and refine our privacy policy. We split the privacy policy into one for the [apps](gdpr), and another separate one for the optional use of the [website](gdpr-website) and community services.
 


### PR DESCRIPTION
on small and mobile screens, the image teared the text into two parts (instead of the text flowing around the image)

before/after:

<img width="300" alt="Screen Shot 2021-11-10 at 20 46 14" src="https://user-images.githubusercontent.com/9800740/141182936-b813d5c3-3fe7-412a-a802-38eeb427871e.png"> <img width="300" alt="Screen Shot 2021-11-10 at 20 46 08" src="https://user-images.githubusercontent.com/9800740/141182927-09700e28-f958-48dd-b310-8cc88df5ed62.png">

i also made the image slightly larger, so that there is an "enhance" effect when coming from the list.

the text is not modified.