### PR TITLE
add a direct android download link (as on desktop)

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -1,6 +1,7 @@
 {% assign txEn = site.data.lang['en']['en'] %}
 {% assign tx = site.data.lang[page.lang][page.lang] %}
 {% assign VERSION_DESKTOP = "1.22.2" %}
+{% assign VERSION_ANDROID = "1.24.4" %}
 
 <div class="download-content">
     <div id="recommendation-section" hidden>
@@ -22,13 +23,10 @@
                 <a href="https://www.amazon.com/dp/B0864PKVW3/" class="img-badge">
                     <img src="../assets/badges/amazon-appstore.png" alt="Available at Amazon Appstore" />
                 </a>
+                <a href="https://download.delta.chat/android/deltachat-gplay-release-{{VERSION_ANDROID}}.apk"><small>Download</small> APK</a>
             </div>
             <div class="descr">
                 <a href="https://github.com/deltachat/deltachat-android">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
-                &ndash;
-                {%if tx.download.dl_apk_text.before != ""%}{{ tx.download.dl_apk_text.before }}{%else%}{{ txEn.download.dl_apk_text.before }}{%endif%}
-                <a href="https://download.delta.chat/android/">APK</a>
-                {%if tx.download.dl_apk_text.after != ""%}{{ tx.download.dl_apk_text.after }}{%else%}{{ txEn.download.dl_apk_text.after }}{%endif%}
             </div>
         </div>
         <div class="box" id="ios">


### PR DESCRIPTION
add a button for the apk as for all other platform links.
previously, the link pointed to https://download.delta.chat/android/
where the user has to figure out the correct file themself
(out of some dozend files :)

little drawback is that `VERSION_ANDROID` needs to be updated on releases, however compared to all the other things to do, this is probably fine (and also allows to change the download link back on issues :)