### PR TITLE
clarify initial setup for translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ see the scripts in the `tools` folder.
 
 - make sure `translate-toolkit` and `transifex-client` are installed
 
-- run following commands
+- run following commands (answer n to the question `Do you want to delete it and reinit the project? [Y/n]:`)
 ```
+cd ./tools
 tx init --user=api --pass=<your api token>
 tx set --auto-remote https://www.transifex.com/projects/p/delta-chat-pages/
+# fix historical typo in word verifiy
+sed -i s#translations/delta-chat-pages.verifiy-downloadspo#translations/delta-chat-pages.verify-downloadspo# .tx/config
 ```
 for more info see the comments in `./tools/t-dance.sh`.
 


### PR DESCRIPTION
There is typo on Transifex in word `verifiy`, locally it is `verify`, after `tx set` command config is updated and `t-dance.sh` script doesn't work corectly. So I added instruction to use sed command to fix it. Best option would be to fix the type on Transifex.

Also I added instruction not to reinit the .tx folder and to run the setup commands in tools folder instead in root of the repo.