### PR TITLE
bump android version to 1.32.0

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -1,7 +1,7 @@
 {% assign txEn = site.data.lang['en']['en'] %}
 {% assign tx = site.data.lang[page.lang][page.lang] %}
 {% assign VERSION_DESKTOP = "1.30.1" %}
-{% assign VERSION_ANDROID = "1.30.3" %}
+{% assign VERSION_ANDROID = "1.32.0" %}
 
 <div class="download-content">
     <div id="recommendation-section" hidden>


### PR DESCRIPTION
this is the version tagged for android, but it makes sense to also release that as usual.  i will also upload 1.32.0 to the stores soonish, ios 1.32 is also shaping up.