### PR TITLE
Add PGP key requirements to the FAQ page

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -340,18 +340,22 @@ passphrase encryption and the password and try the import again.  If you want
 to keep your passphrase you'll have to create an e-mail alias for use
 with Delta Chat such that Delta Chat's key is tied to this e-mail alias.
 
-Delta Chat supports common OpenPGP private key formats, however, it
-is unlikely that private keys from all sources will be fully supported. This
-is not the main goal of Delta Chat. In fact, the majority of new users 
-will not have any key prior to using Delta Chat.
-We do, however, try to support private keys from as many sources as possible. 
-
 Removing the password from the private key will depend on the
 software you use to manage your PGP keys. With Enigmail, you can set your
 password to an empty value in the Key Management window. With GnuPG you can set
 it [via the command
 line](https://github.com/deltachat/deltachat-android/issues/98#issuecomment-378383429).
 For other programs, you should be able to find a solution online.
+
+Delta Chat supports common OpenPGP private key formats, however, it
+is unlikely that private keys from all sources will be fully supported. This
+is not the main goal of Delta Chat. In fact, the majority of new users 
+will not have any key prior to using Delta Chat.
+We do, however, try to support private keys from as many sources as possible. 
+
+Delta Chat will **not** recognize 4096-bit RSA keys. It is
+[recommended](https://autocrypt.org/faq.html#why-also-rsa3072-and-not-only-curve-25519-keys)
+to use Ed25519 or 3072-bit RSA keys.
 
 
 ### Why don't you use pEp (pretty easy privacy)?


### PR DESCRIPTION
It took me a few hours to figure out why I can't import my existing RSA4096 key on both my devices. The app only sad that it didn't find any private key in the folder. If the key check won't be implemented, then at least the FAQ page should have an explanation of the bug.