### PR TITLE
add toc and static anchor for donate to contribute page

### DIFF
--- a/en/contribute.md
+++ b/en/contribute.md
@@ -2,9 +2,10 @@
 title: Contribute
 lang: en
 render_toc: true
+header: Contribute or Donate
 ---
 
-# Channels and repositories
+## Channels and repositories
 
 - [Fediverse](https://chaos.social/web/@delta) and
   [Twitter](https://twitter.com/delta_chat) for announcements.
@@ -21,7 +22,7 @@ render_toc: true
 - [Delta Chat repositories](https://github.com/deltachat/) where you can 
   find the code for DeltaChat apps and this web site.
 
-# Translations and Bug Reports 
+## Translations and Bug Reports 
 
 - [Translations on Transifex](https://www.transifex.com/delta-chat/public/)
 - [Delta Chat Android Issues](https://github.com/deltachat/deltachat-android/issues)
@@ -37,7 +38,7 @@ Please don't hesitate to reach out (delta at merlinux eu) if you are interested 
 
 <a id="donate-anchor"></a><!-- don't translate this html anchor!-->
 
-# Donate Money 
+## Donate Money 
 
 If you monetarily support DeltaChat you help it to stay and grow as an independent project that works and is oriented towards its users: 
 

--- a/en/contribute.md
+++ b/en/contribute.md
@@ -1,6 +1,7 @@
 ---
 title: Contribute
 lang: en
+render_toc: true
 ---
 
 # Channels and repositories
@@ -33,6 +34,8 @@ C, Rust, Java, Swift, Javascript or Python on Android, iOS, Windows, Linux or Ma
 We typically offer 20 hours per week contracts or employments (if based in germany). 
 Please don't hesitate to reach out (delta at merlinux eu) if you are interested to help our efforts!
 
+
+<a id="donate-anchor"></a><!-- don't translate this html anchor!-->
 
 # Donate Money 
 


### PR DESCRIPTION
Table of Contents is that people can directly see a link to the donate section.
Anchor is that we can link to the donate section from the apps: https://delta.chat/contribute#donate-anchor (notice the missing language in path, this will be replaced by automatically the user's language and the static (not translated anchor) ensures they jump to the right place on all languages).

we need to regenerate/upload the thing to/from transifex after merging. ping @r10s 

this is a first step, I think we need a dedicated site for money donation sometime anyways.
Also the text could be updated, liberapay is only recurring payments for example (that info is missing).