### PR TITLE
Link to cosmos

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,8 @@
 
 <link rel="stylesheet" href="../assets/css/styles.css" type="text/css" />
 <link rel="alternate" href="https://delta.chat/feed.xml" type="application/atom+xml" title="{%if tx.rss_news_title != ""%}{{ tx.rss_news_title }}{%else%}{{ txEn.rss_news_title }}{%endif%}" />
+<script defer src="https://cosmos.delta.chat/banner.js"></script>
+<link rel="stylesheet" href="https://cosmos.delta.chat/banner.css" type="text/css" />
 </head>
 
 <body id="top">


### PR DESCRIPTION
This adds a small banner to the bottom of the page similar to https://cosmos.delta.chat so that readers can easily be aware of and discover various sites related to Delta Chat.