### PR TITLE
IRC and mailing list are not used really -- link to groupsbot instead

### DIFF
--- a/en/contribute.md
+++ b/en/contribute.md
@@ -7,22 +7,18 @@ lang: en
 
 For community interactions around Delta Chat please read our [Community Standards](community-standards).
 
-- [Fediverse](https://chaos.social/web/@delta) for announcements;
-  [leaving twitter](https://twitter.com/delta_chat/status/1603771336060436483).
+- [Fediverse](https://chaos.social/web/@delta) for announcements and feedback.
+
+- With your Delta Chat app you can send a `/list` message to [a community
+  groups bot (groupsbot@hispanilandia.net)](mailto:groupsbot@hispanilandia.net) to discover and join various chat groups.
 
 - [Delta Chat support forum](https://support.delta.chat) for wider
   feature discussions and getting support.
 
-- [#deltachat on Libera.Chat]({% include webirc-url %}) for day to day communications.
-
-- [Delta Chat mailing
-  list](https://lists.codespeak.net/postorius/lists/delta.codespeak.net/) 
-  for community discussions and news.
-
-- [Delta Chat repositories](https://github.com/deltachat/) where you can 
+- [Delta Chat repositories](https://github.com/deltachat/) where you can
   find the code for DeltaChat apps and this web site.
-  
-- Other links can be found in the [cosmos](https://cosmos.delta.chat)
+
+- More links can be found in the [cosmos](https://cosmos.delta.chat)
 
 [Donate Money](donate){: .cta-button}
 
@@ -34,7 +30,9 @@ For community interactions around Delta Chat please read our [Community Standard
 - [Delta Chat iOS Issues](https://github.com/deltachat/deltachat-ios/issues)
 - [Rust Core Library + Python Bindings Issues](https://github.com/deltachat/deltachat-core-rust/issues)
 
-We are always looking for developers and designers who want to help along and are familiar with 
-C, Rust, Java, Swift, Javascript or Python on Android, iOS, Windows, Linux or Mac.
-We typically offer 20 hours per week contracts or employments (if based in germany). 
-Please don't hesitate to reach out (delta at merlinux eu) if you are interested to help our efforts!
+We are always looking for developers and designers.
+We typically offer 20-30 hours per week contracts or employments (if based in germany).
+Please don't hesitate to reach out (delta at merlinux eu)
+if you are interested to help our efforts!
+
+For more background we recommend to read and follow our (blog)[https://delta.chat/en/blog].


### PR DESCRIPTION
this strikes the link to IRC and (non-dc) mailing list -- we don't really use it anyway.  
It attempts to link to the groupsbot .... maybe someone could test and make sure the link to the groupsbot makes sense? Feel free to directly fix/commit to this branch.  thanks!