### PR TITLE
Serverguide update

### DIFF
--- a/en/serverguide.md
+++ b/en/serverguide.md
@@ -318,11 +318,11 @@ Add the following lines to each container in
 `mailcow-dockerized/docker-compose.yml`:
 
 ```
-    logging:
-      driver: "syslog"
-      options:
-        syslog-address: "udp://127.0.0.1:514"
-        syslog-facility: "local3"
+      logging:
+        driver: "syslog"
+        options:
+          syslog-address: "udp://127.0.0.1:514"
+          syslog-facility: "local3"
 ```
 
 Now you can configure rsyslog to listen on that port for log input. Uncomment

--- a/en/serverguide.md
+++ b/en/serverguide.md
@@ -341,7 +341,7 @@ local3.*        /dev/null
 ```
 
 Finally, restart rsyslog with `sudo service rsyslog restart` and mailcow with
-`sudo docker-compose up -d`.
+`sudo docker compose up -d`.
 
 Consider looking at the [Mailcow logging
 documentation](https://docs.mailcow.email/post_installation/firststeps-logging/#log-rotation)


### PR DESCRIPTION
fixed syslog stanza indentation, and updated the last `docker-compose` to `docker compose`