### PR TITLE
add security info to home page

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -9,7 +9,7 @@ lang: en
 
 🥳 Enjoy interactive chat experiences through [webxdc apps](https://webxdc.org).
 
-🔒 All your data stays on your device and email account.
+🔒 End-to-End Encryption using [Autocrypt](https://autocrypt.org) and [CounterMITM](https://countermitm.readthedocs.io/en/latest/new.html) protocols, with [multiple security audits](https://delta.chat/en/2023-03-27-third-independent-security-audit). Your data stays on your device and e-mail account. 
 
 # Available on mobile and desktop
 

--- a/en/index.md
+++ b/en/index.md
@@ -9,7 +9,7 @@ lang: en
 
 🥳 Enjoy interactive chat experiences through [webxdc apps](https://webxdc.org).
 
-🔒 End-to-End Encryption using [Autocrypt](https://autocrypt.org) and [CounterMITM](https://countermitm.readthedocs.io/en/latest/new.html) protocols, with [multiple security audits](https://delta.chat/en/2023-03-27-third-independent-security-audit). Your data stays on your device and e-mail account. 
+🔒 End-to-End Encryption using [Autocrypt](https://autocrypt.org) and [CounterMITM](https://countermitm.readthedocs.io/en/latest/new.html) protocols, with [multiple security audits](https://delta.chat/en/2023-03-27-third-independent-security-audit). 
 
 # Available on mobile and desktop
 


### PR DESCRIPTION
Finally, it is time to have something on the home page and link Autocrypt/Countermitm directly, and also the audits. 
With this, the third point on the home page is similar to the first two points in that it contains / points to links for "more". 