### PR TITLE
improve mobile-layout: do not start text right of image

### DIFF
--- a/_posts/2023-05-22-webxdc-security.md
+++ b/_posts/2023-05-22-webxdc-security.md
@@ -227,6 +227,7 @@ that try to identify VPN users.
 ### Maybe using Firefox engines would help us? 
 
 <img src="../assets/blog/2023-05-20-allchrome.png" width="270" style="float:right; margin-left:0.5em;" />
+
 Delta Chat apps do not use Firefox webviews which can be directly configured
 to disable WebRTC, by setting `media.peerconnection.enabled = false` in `about:config`.
 Firefox can do DNS-prefetching but it thankfully again appears like 


### PR DESCRIPTION
this simple line break ensures, the text on mobile is not starting directly after the image: before/after:

<img width=300 src=https://github.com/deltachat/deltachat-pages/assets/9800740/1f2118dc-b281-4cf8-a2ae-835567674f4c> <img width=300 src=https://github.com/deltachat/deltachat-pages/assets/9800740/869dfbaf-8652-44a7-bec9-d46c9a97929d>

on non-mobile (with larger screen widths), things are floating as expected:

<img width=480 src=https://github.com/deltachat/deltachat-pages/assets/9800740/d964f15c-c2d6-4cd5-92fa-52fdb9dba8dd>

<a name=gist> 

as there is always some confusion about images in blogs:

# this is the gist of the current CSS wrt images

- create images with reasonable sizes, they can be large (say, up to 400px width or so)  to look good on desktop. let them float left/right or not at all (so `<img style="float: left" ...>`, `<img style="float: right" ...>` or just `<img ...>` (the latter is recommended for images > 400px)

- unless you are forcing things using `!important` (which is not recommended at scale) on smaller screens, this floating turns to "own paragraph for the image" - but for that, an **empty line** is important

that's it, that way, images are not _that_ bad on desktop as well as on mobile. the approach of turning floating to non-floating is used in many blogs afaik. of course, things can be improved :)

i think, we should add this information also to the readme
