### PR TITLE
more image fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ How to create a new blog post
 - Write your blog post to the file and do not forget 
   to add or modify the `title:` and `author:` line atop it.
 
+- **images up to a width of ~400px**
+  can be added with `<img style="float: left" ...>` or `<img style="float: left" ...>` -
+  on small mobile screens, where floating is barely possible, these images will get their own paragraph
+  in case you add an **empty line** after the images (also see existing blog posts as a pattern)
+
+- for **larger images** or if you do not want floating,
+  omit the floating rule and just use `<img ...>` followed by an **empty line**;
+  these images always get their own paragraph then
+
 - That's all, the result goes to https://delta.chat/en/blog , and the
   [RSS-Feed](https://delta.chat/feed.xml).
 

--- a/_posts/2020-06-24-releases.md
+++ b/_posts/2020-06-24-releases.md
@@ -11,6 +11,7 @@ here is an overview about what you can expect from **Delta Chat 1.10:**
 ### It's faster!
 
 <img src="../assets/blog/2020-06-faster.jpg" width="240" style="float:left; clear:both; margin-right:1em; margin-bottom:.2em;" alt="" />
+
 _"Stand back while Delta Chat's core Rust lib is fully moving to Async"_
 was [Holger's advice on Twitter](https://twitter.com/delta_chat/status/1261386305247690752)
 when the Async move was started.
@@ -37,6 +38,7 @@ Thanks a lot to our chief magician _dignifiedquire_ to make this possible ✨
 ### Blur Images
 
 <img src="../assets/blog/2020-06-blur.jpg" width="200" style="float:right; clear:both; margin-left:.2em; margin-bottom:.2em;" alt="A blurred image" /> 
+
 Shot a photo you want to post - but there are some **details on the photo you do not want to be spread?**
 A license plate, a clock with the date, a marker on a jacket that will identify the person, a face?
 

--- a/_posts/2020-07-30-summer-update.md
+++ b/_posts/2020-07-30-summer-update.md
@@ -40,6 +40,7 @@ together with different user groups and testers,
 and driven by UX-research and interviews.
 
 <img src="../assets/blog/2020-07-scan-videochat-provider.jpg" width="320" style="float:right; clear:both; margin-left:1em; margin-bottom:.2em;" alt="" />
+
 So - it is **up to the user to decide which video chat provider to use.**
 
 - They can enter it in the **settings**
@@ -53,6 +54,7 @@ The user can use every instance that contains the room-name in the URL, which in
 services as jitsi, talky.io, appear.in and many more.
 
 <img src="../assets/blog/2020-07-videochat-invite2.png" width="220" style="float:right; clear:both; margin-left:1em; margin-bottom:.2em;" alt="" />
+
 We believe in widely decentralizing the video chat services
 is a good idea for overall privacy.
 Enabling the user to use any existing instance or hosting their own helps a lot for this approach.
@@ -81,6 +83,7 @@ Another new feature in all recent Delta Chat versions on all platforms are the s
 _Disappearing messages_, similar to the Signal messenger offering.  
 
 <img src="../assets/blog/2020-07-disappearing-options.png" width="250" style="float:left; clear:both; margin-right:1em; margin-bottom:.2em;" alt="" />
+
 Once the feature is enabled in the settings,
 any user can decide to see all subsequent messages disappearing.
 

--- a/_posts/2020-11-05-android-update.md
+++ b/_posts/2020-11-05-android-update.md
@@ -14,6 +14,7 @@ What can you expect from **Delta Chat Android 1.14?**
 ## Swipe to Reply
 
 <img src="../assets/blog/2020-11-swipe-to-reply.jpg" width="330" style="float: left; clear:both; margin-right:1em; margin-bottom:.2em;" alt="User thumb shown swiping a message." />
+
 A long awaited feature is now here.
 Not much to explain — this is well known from other apps:
 
@@ -34,6 +35,7 @@ that takes care of the **_really_ hard stuff:**
 Crypto, network, protocols, database — you get the idea.
 
 <img src="../assets/blog/2020-11-machine-room.jpg" width="330" style="float: right; clear:both; margin-left:1em; margin-bottom:.2em;" alt="Some art-like connected electronics on a shaded wall." />
+
 Changes in the core are not directly visible to the user.
 The rationale is:
 If you do not notice the core, it does **the best job it can do.**
@@ -61,6 +63,7 @@ A big "thank you" for this incredible work!
 ## Some more things
 
 <img src="../assets/blog/2020-11-disappearing.jpg" width="330" style="float: right; clear:both; margin-left:1em; margin-bottom:.2em;" alt="Phone screen showing alternatives for how long messages should be retained." />
+
 Some other features at a glance:
 
 * **Disappearing messages**,

--- a/_posts/2021-05-05-email-compat.md
+++ b/_posts/2021-05-05-email-compat.md
@@ -17,6 +17,7 @@ _A notification from a parcel service?_
 _An invitation?_
 
 <img src="../assets/blog/2021-05-html-mail.jpg" width="250" style="float: right; clear:both; margin-left:.1em; margin-bottom:.2em;" alt="Screenshot with &quot;Show classic e-mails&quot; option" />
+
 All these messages may come as **rich-formatted HTML-mails**,
 that are now displayed nicely directly inside Delta Chat 1.20.
 

--- a/_posts/2022-06-14-webxdcintro.md
+++ b/_posts/2022-06-14-webxdcintro.md
@@ -6,6 +6,7 @@ com_id: 108487984933980780
 ---
 
 <img src="../assets/logos/webxdc2.png" style="width:160px; float:right; clear:both; margin-left:.5em; margin-bottom:.2em;" alt="Webxdc Logo" />
+
 Delta Chat 1.30 introduces support for [webxdc apps](https://webxdc.org): which makes it possible to share HTML5 apps (packaged as <code>.xdc</code> files) inside your chats, so that any participant can run the app by clicking "Start" in the message.  It transforms Delta Chat into an *extensible* messenging app where third parties can easily program custom interactive chat extensions, called "webxdc apps".
 
 ## Sharing webxdc apps is safe and easy 

--- a/_posts/2022-12-15-uidevjob.md
+++ b/_posts/2022-12-15-uidevjob.md
@@ -29,6 +29,7 @@ You guessed it: they're using or interested in Delta Chat because it is:
 ### Why don't we spend more time on promotion?
 
 <img src="../assets/blog/2020-06-faster.jpg" width="270" style="float:right; margin-left:1em;" />
+
 Since the beginnings of Delta Chat in a small city north of Hamburg almost five years ago,
 we have posted little about the wonderful and diverse ways people use our apps.
 We usually prefer to share completed releases instead of pre-announcing or
@@ -42,6 +43,7 @@ about how we are doing things and about job offers to join our UX-oriented devel
 ### Sharing web apps in a chat (webxdc)
 
 <img src="../assets/blog/2022-12-webxdc-poll.jpg" width="270" style="float:right; margin-left:1em;" />
+
 [Sharing web apps in a chat (webxdc)](https://webxdc.org) was released in mid-2022.
 Dozens of grassroots-ported games are now played everyday in chat groups and through mailing lists.
 Collaborative tooling apps (polls, checklists, calendars, editors) are evolving.
@@ -65,6 +67,7 @@ it features these wonderful properties and UX conveniences:
 - **no logins or GDPR/consent screens**.
 
 <img src="../assets/blog/gordon_superapp.jpg" width="270" style="float:right; margin-left:1em;" />
+
 UX and privacy researchers and hackers from diverse projects such as CryptPad, DAT, IPFS,
 Peermaps and Libreoffice agree:
 Web tech combined with decentralized chat (aka "webxdc") is a rare jewel worth refining.
@@ -72,6 +75,7 @@ Web tech combined with decentralized chat (aka "webxdc") is a rare jewel worth r
 ### Movements in the woods and underground…
 
 <img src="../assets/blog/2022-12-stickers-and-beer.jpg" width="270" style="float:right; margin-left:1em;" />
+
 With a wide variety of users, developers, partners, and co-operative projects
 we discuss many wants and needs:
 Supporting emoji-reactions, having Telegram-style larger channels,
@@ -131,6 +135,7 @@ you will need to migrate, and Automatic Accounts have the design goal of making 
 ### The coming migrations
 
 <img src="../assets/blog/blaine-fediverse.png" width="270" style="float:right; margin-left:1em;" />
+
 Speaking of migrations, we have more followers on the Fediverse than on Twitter
 and interesting conversations are evolving on the Fediverse.
 Aren't e-mail addresses and fediverse addresses strangely similar?
@@ -146,6 +151,7 @@ not new barriers and walled gardens.
 ### Our Rust-core architecture (tm) and its UI bindings…
 
 <img src="../assets/blog/rust-delta.png" width="270" style="float:right; margin-left:1em;" />
+
 Delta Chat was the first fully Rust-based chat app available
 on all platforms, and may still be the only one.
 Rust is a system-level memory-safe language,

--- a/_posts/2023-05-22-webxdc-security.md
+++ b/_posts/2023-05-22-webxdc-security.md
@@ -193,6 +193,7 @@ we did not expect it would be so hard to control the network behaviour of web co
 ### Browsers: please implement the W3C "WEBRTC: block" directive
 
 <img src="../assets/logos/w3c_home.svg" width="170" style="float:left ; margin-right:0.5em;" />
+
 Platforms serving web pages or apps need to trust their complete
 supply chain of JavaScript dependencies if they don't want
 users of their offerings to leak app data through WebRTC.


### PR DESCRIPTION
avoiding the text starting after the image on small screens on recent blog posts, and add a note for that to the README.

this was partly "okay", but by copy+paste somehow forgotten in more recent posts :)

successor of https://github.com/deltachat/deltachat-pages/pull/672

closes #596
replaces #597 