### PR TITLE
only post preview link once

### DIFF
--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -56,7 +56,7 @@ jobs:
           export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           echo $RESPONSE > result
           cat result
-          if [ ! grep '"Check out the page preview at https://staging.delta.chat/' result ]; then echo ::set-output name=comment::true ;fi
+          grep -v '"Check out the page preview at https://staging.delta.chat/' result && echo ::set-output name=comment::true ;fi
       - name: "Post link to comments"
         if: steps.details.outputs.comment
         uses: actions/github-script@v6

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -53,7 +53,7 @@ jobs:
           export RESPONSE=$(curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message)
           echo $RESPONSE
           export GITHUB_API_URL="https://api.github.com/repos/deltachat/deltachat-pages/issues/${{ steps.prepare.outputs.prid }}/comments"
-          export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28"
+          export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           echo $RESPONSE
           if [ "$RESPONSE" == "Not Found" ]; then echo ::set-output name=comment::true ;fi
           if [ "$RESPONSE" == "null" ]; then echo ::set-output name=comment::true ;fi

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -49,13 +49,13 @@ jobs:
                                \"description\": \"Preview the page here:\", \
                                \"context\": \"Page Preview\", \
                                \"target_url\": \"${PREVIEW_LINK}\"}"
-          #curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message
-          export RESPONSE=$(curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message)
-          echo $RESPONSE
+          curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA"
+
+          #check if comment already exists, if not post it
           export GITHUB_API_URL="https://api.github.com/repos/deltachat/deltachat-pages/issues/${{ steps.prepare.outputs.prid }}/comments"
           export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           echo $RESPONSE > result
-          grep '"Check out the page preview at https://staging.delta.chat/' result && 
+          cat result
           if [ ! grep '"Check out the page preview at https://staging.delta.chat/' result ]; then echo ::set-output name=comment::true ;fi
       - name: "Post link to comments"
         if: steps.details.outputs.comment

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -54,9 +54,9 @@ jobs:
           echo $RESPONSE
           export GITHUB_API_URL="https://api.github.com/repos/deltachat/deltachat-pages/issues/${{ steps.prepare.outputs.prid }}/comments"
           export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
-          echo $RESPONSE
-          if [ "$RESPONSE" == "Not Found" ]; then echo ::set-output name=comment::true ;fi
-          if [ "$RESPONSE" == "null" ]; then echo ::set-output name=comment::true ;fi
+          echo $RESPONSE > result
+          grep '"Check out the page preview at https://staging.delta.chat/' result && 
+          if [ ! grep '"Check out the page preview at https://staging.delta.chat/' result ]; then echo ::set-output name=comment::true ;fi
       - name: "Post link to comments"
         if: steps.details.outputs.comment
         uses: actions/github-script@v6

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -52,6 +52,9 @@ jobs:
           #curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message
           export RESPONSE=$(curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message)
           echo $RESPONSE
+          export GITHUB_API_URL="https://api.github.com/repos/deltachat/deltachat-pages/issues/${{ steps.prepare.outputs.prid }}/comments"
+          export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28"
+          echo $RESPONSE
           if [ "$RESPONSE" == "Not Found" ]; then echo ::set-output name=comment::true ;fi
           if [ "$RESPONSE" == "null" ]; then echo ::set-output name=comment::true ;fi
       - name: "Post link to comments"

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -55,7 +55,7 @@ jobs:
           export GITHUB_API_URL="https://api.github.com/repos/deltachat/deltachat-pages/issues/${{ steps.prepare.outputs.prid }}/comments"
           export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           echo $RESPONSE > result
-          grep -v '"Check out the page preview at https://staging.delta.chat/' result && echo ::set-output name=comment::true
+          grep -v '"Check out the page preview at https://staging.delta.chat/' result && echo ::set-output name=comment::true || true
       - name: "Post link to comments"
         if: steps.details.outputs.comment
         uses: actions/github-script@v6

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -49,8 +49,11 @@ jobs:
                                \"description\": \"Preview the page here:\", \
                                \"context\": \"Page Preview\", \
                                \"target_url\": \"${PREVIEW_LINK}\"}"
-          curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message
+          #curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message
+          export RESPONSE=$(curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message)
+          echo $RESPONSE
       - name: "Post link to comments"
+        if: false
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -53,6 +53,7 @@ jobs:
           export RESPONSE=$(curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message)
           echo $RESPONSE
           if [ "$RESPONSE" == "Not Found" ]; then echo ::set-output name=comment::true ;fi
+          if [ "$RESPONSE" == "null" ]; then echo ::set-output name=comment::true ;fi
       - name: "Post link to comments"
         if: steps.details.outputs.comment
         uses: actions/github-script@v6

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -52,8 +52,9 @@ jobs:
           #curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message
           export RESPONSE=$(curl -X POST --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/json" --data "$STATUS_DATA" | jq -r .message)
           echo $RESPONSE
+          if [ "$RESPONSE" == "Not Found" ]; then echo ::set-output name=comment::true ;fi
       - name: "Post link to comments"
-        if: false
+        if: steps.details.outputs.comment
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -56,7 +56,7 @@ jobs:
           export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           echo $RESPONSE > result
           cat result
-          grep -v '"Check out the page preview at https://staging.delta.chat/' result && echo ::set-output name=comment::true ;fi
+          grep -v '"Check out the page preview at https://staging.delta.chat/' result && echo ::set-output name=comment::true
       - name: "Post link to comments"
         if: steps.details.outputs.comment
         uses: actions/github-script@v6

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -55,7 +55,6 @@ jobs:
           export GITHUB_API_URL="https://api.github.com/repos/deltachat/deltachat-pages/issues/${{ steps.prepare.outputs.prid }}/comments"
           export RESPONSE=$(curl -L --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --url "$GITHUB_API_URL" --header "content-type: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           echo $RESPONSE > result
-          cat result
           grep -v '"Check out the page preview at https://staging.delta.chat/' result && echo ::set-output name=comment::true
       - name: "Post link to comments"
         if: steps.details.outputs.comment


### PR DESCRIPTION
Now the GitHub action checks whether the comment with the link was already posted, and only posts it if it's missing so far.