### PR TITLE
Update minimum desktop os versions

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -16,7 +16,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
 Minimal requirements:
 Android 4.1 Jelly Bean
 or iOS 11, iPhone 5s or iPad 5/Air/Mini
-or Windows 7, macOS 10.11 El Capitan, Ubuntu 20.04, Fedora 29 or Debian 10
+or Windows 7, macOS 10.11 El Capitan, Ubuntu 18.04, Fedora 29 or Debian 10
 or compatible systems.
 
 ## Links

--- a/en/download.md
+++ b/en/download.md
@@ -16,7 +16,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
 Minimal requirements:
 Android 4.1 Jelly Bean
 or iOS 11, iPhone 5s or iPad 5/Air/Mini
-or Windows 7, macOS 10.11 El Capitan, Ubuntu 22.04, Fedora 29 or Debian 10
+or Windows 7, macOS 10.11 El Capitan, Ubuntu 20.04, Fedora 29 or Debian 10
 or compatible systems.
 
 ## Links

--- a/en/download.md
+++ b/en/download.md
@@ -16,7 +16,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
 Minimal requirements:
 Android 4.1 Jelly Bean
 or iOS 11, iPhone 5s or iPad 5/Air/Mini
-or Windows 7, macOS 10.11 El Capitan, Ubuntu 22.04, Fedora 31 or Debian 10
+or Windows 7, macOS 10.11 El Capitan, Ubuntu 22.04, Fedora 29 or Debian 10
 or compatible systems.
 
 ## Links

--- a/en/download.md
+++ b/en/download.md
@@ -16,7 +16,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
 Minimal requirements:
 Android 4.1 Jelly Bean
 or iOS 11, iPhone 5s or iPad 5/Air/Mini
-or Windows 7, macOS 10.10 Yosemite, Ubuntu 12.04, Fedora 21 or Debian 8
+or Windows 7, macOS 10.11 El Capitan, Ubuntu 22.04, Fedora 31 or Debian 10
 or compatible systems.
 
 ## Links


### PR DESCRIPTION
could be that older versions of ubuntu still work, but this is the LTS release. I also guessed a bit for fedora based on release dates. min macOS comes from https://www.electronjs.org/de/docs/latest/tutorial/unterstützung