### PR TITLE
set an explicit #changelogs anchor

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -4,7 +4,7 @@ lang: en
 downloads: true
 ---
 
-## Changelogs
+## Changelogs {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)
 * [Android](https://github.com/deltachat/deltachat-android/blob/master/CHANGELOG.md)


### PR DESCRIPTION
that way, the anchor don't get translated and we can use sth. as get.delta.chat#changelogs that redirects to the correct headline in all languages

closes #698
