### PR TITLE
use full/correct name of deltachat-core-rust repo

### DIFF
--- a/_posts/2023-07-02-deltatouch.md
+++ b/_posts/2023-07-02-deltatouch.md
@@ -5,7 +5,7 @@ image: ../assets/blog/2023-07-openstore-badge.png
 com_id: 110650443882930357
 ---
 
-Hi, this is Lothar aka [lk108](https://social.tchncs.de/@lk108). I'm today's guest on the blog and it's my pleasure to introduce DeltaTouch, a third-party client based on deltachat-core for the mobile phone OS [Ubuntu Touch](https://ubports.com) (UT). The app has just been [released on the OpenStore](https://open-store.io/app/deltatouch.lotharketterer) for both the xenial and the focal channel of UT. Here's what it looks like:
+Hi, this is Lothar aka [lk108](https://social.tchncs.de/@lk108). I'm today's guest on the blog and it's my pleasure to introduce DeltaTouch, a third-party client based on deltachat-core-rust for the mobile phone OS [Ubuntu Touch](https://ubports.com) (UT). The app has just been [released on the OpenStore](https://open-store.io/app/deltatouch.lotharketterer) for both the xenial and the focal channel of UT. Here's what it looks like:
 
 <img src="../assets/blog/2023-07-chatlist.png" style="width:230px;" alt="" />
 <img src="../assets/blog/2023-07-surudark.png" style="width:230px;" alt="" />


### PR DESCRIPTION
Referring to the core repo as deltachat-core instead of the full name deltachat-core-rust lead to confusion. Suggest to use the full name.