### PR TITLE
Defer loading of banner.css

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
 <link rel="stylesheet" href="../assets/css/styles.css" type="text/css" />
 <link rel="alternate" href="https://delta.chat/feed.xml" type="application/atom+xml" title="{%if tx.rss_news_title != ""%}{{ tx.rss_news_title }}{%else%}{{ txEn.rss_news_title }}{%endif%}" />
 <script defer src="https://cosmos.delta.chat/banner.js"></script>
-<link rel="stylesheet" href="https://cosmos.delta.chat/banner.css" type="text/css" />
+<link rel="preload" href="https://cosmos.delta.chat/banner.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 </head>
 
 <body id="top">


### PR DESCRIPTION
TLS setup to cosmos.delta.chat sometimes takes too long, postponing rendering.

Defer loadin of CSS as described on
https://web.dev/defer-non-critical-css/

There is no <noscript> tag because the banner is
not created without JavaScript anyway.