### PR TITLE
remove body from mailto links because they cause issues when copy-pasting

### DIFF
--- a/_posts/2023-08-11-xstore.md
+++ b/_posts/2023-08-11-xstore.md
@@ -36,7 +36,7 @@ and how the whole thing works.
 <img src="../assets/blog/2023-08-xstore-start.png" width="240" style="float:right; margin-left:1em;" />  
 With Delta Chat already working it's dead simple to **start**:
 
-1. Say "hi" to [xstore@testrun.org](mailto:xstore@testrun.org?body=hi)
+1. Say "hi" to [xstore@testrun.org](mailto:xstore@testrun.org)
    and hit **Start** on the returned webxdc store app. 
 
 2. Select a game or collaborative app for download.
@@ -136,7 +136,7 @@ and hope you join the fun with webxdc apps :)
 ## How does xstore work? Where does it get its apps from? 
 
 <img src="../assets/logos/store.png" width="140" style="float:right; margin-left:1em;" />  
-[xstore@testrun.org](mailto:xstore@testrun.org?body=hi) is a chat bot instance.
+[xstore@testrun.org](mailto:xstore@testrun.org) is a chat bot instance.
 After you send “Hi” to the bot,
 you receive and start the store app,
 which continues to communicate with the bot
@@ -168,7 +168,7 @@ from git public repositories.
 - If you deleted the store or
   chose "clear chat" to clean up,
   you can at any point in time just send "hi"
-  to [xstore@testrun.org](mailto:xstore@testrun.org?body=hi) again,
+  to [xstore@testrun.org](mailto:xstore@testrun.org) again,
   and it will re-send the store to the chat.
 - Only one chat member needs to use xstore@testrun.org while
 all others can just start the app they receive in the chat, 
@@ -177,7 +177,7 @@ and without any kind of central tracking.
 - If you use the XMPP messenger cheogram,
   xstore will not work for you yet;
   but with upcoming support for webxdc in XMPP/e-mail bridges
-  you might be able to message [xstore@testrun.org](mailto:xstore@testrun.org?body=hi)
+  you might be able to message [xstore@testrun.org](mailto:xstore@testrun.org)
   and download apps from there.
 
 ## Thanks to NLNET and NGI for their support and vision!


### PR DESCRIPTION
if you copy-paste `xstore@testrun.org?body=hi` into delta's search field, it doesn't know how to ignore the part after the `?`.