### PR TITLE
avoid links in headlines that go to TOC

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -335,7 +335,7 @@ see also our answers to [device-seizure](#device-seizure)
 and [message-metadata](#message-metadata) questions. 
 
 
-### Is Delta Chat vulnerable to [EFAIL](https://efail.de/)?
+### Is Delta Chat vulnerable to EFAIL?
 
 [Delta Chat never was vulnerable to EFAIL](https://delta.chat/en/2018-05-15-delta-chat-not-vulnerable-to-efail)
 because its OpenPGP implementation [rPGP](https://github.com/rpgp/rpgp) 


### PR DESCRIPTION
these links look weird in the TOC - but also as a real headline.

also, it feels wrong to have a first link that tend frighten ppl - where only the next link to our blog says, "no, everything is fine".

so, the link to the blog post, is the better source for diving deeper into the topic, as it deals with
Delta Chat wrt EFAIL and not only EFAIL.

finally, we also do not link PGP, OpenPGP etc. in the headlines (a link is not really a part of a question).