### PR TITLE
Fix loading of webp images

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -14,39 +14,45 @@ lang: en
 # Available on mobile and desktop
 
 
+<div>
+<a href="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-chat-list-light.png">
 <picture>
 <source srcset="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-chat-list-light-thumbnail.webp" type="image/webp" />
 <source srcset="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-chat-list-light-thumbnail.png" type="image/png" />
-<a href="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-chat-list-light.png">
-<img src="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-chat-list-light-thumbnail.png" width="120" height="213"
-style="float: left; margin: 10px;display: block;box-shadow: 5px 5px 2px #777;" alt="A screenshot of Delta Chat on Android showing chat list" />
-</a> 
+<img src="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-chat-list-light-thumbnail.png" width="120" height="213" style="float: left; margin: 10px;display: block;box-shadow: 5px 5px 2px #777;" alt="A screenshot of Delta Chat on Android showing chat list" />
 </picture>
+</a>
+</div>
 
+<div>
+<a href="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-group-light.png">
 <picture>
 <source srcset="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-group-light-thumbnail.webp" type="image/webp" />
 <source srcset="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-group-light-thumbnail.png" type="image/png" />
-<a href="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-group-light.png">
-<img src="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-group-light-thumbnail.png" width="120" height="213"
-style="float: left; margin: 10px;display: block;box-shadow: 5px 5px 2px #777;" alt="A screenshot of Delta Chat on Android showing a chat" />
-</a> 
+<img src="../assets/blog/screenshots/2019-12-17-delta-chat-google-play-release-group-light-thumbnail.png" width="120" height="213" style="float: left; margin: 10px;display: block;box-shadow: 5px 5px 2px #777;" alt="A screenshot of Delta Chat on Android showing a chat" />
 </picture>
+</a>
+</div>
 
+<div>
+<a href="../assets/blog/desktop-screenshot.png">
 <picture>
 <source srcset="../assets/blog/desktop-screenshot-thumbnail.webp" type="image/webp" />
 <source srcset="../assets/blog/desktop-screenshot-thumbnail.png" type="image/png" />
-<a href="../assets/blog/desktop-screenshot.png">
 <img src="../assets/blog/desktop-screenshot-thumbnail.png" width="280" height="222" style="float:left; margin: 10px" alt="A screenshot of Delta Chat on desktop" />
-</a> 
 </picture>
+</a>
+</div>
 
+<div>
+<a href="../assets/blog/screenshots/2020-01-09-delta-chat-iOS-weekend-group-chat.png">
 <picture>
 <source srcset="../assets/blog/screenshots/2020-01-09-delta-chat-iOS-weekend-group-chat-thumbnail.webp" type="image/webp" />
 <source srcset="../assets/blog/screenshots/2020-01-09-delta-chat-iOS-weekend-group-chat-thumbnail.png" type="image/png" />
-<a href="../assets/blog/screenshots/2020-01-09-delta-chat-iOS-weekend-group-chat.png">
-<img src="../assets/blog/screenshots/2020-01-09-delta-chat-iOS-weekend-group-chat-thumbnail.png" width="110" height="219" style="margin: 10px" alt="A screenshot of Delta Chat on IOS" />
-</a>
+<img src="../assets/blog/screenshots/2020-01-09-delta-chat-iOS-weekend-group-chat-thumbnail.png" width="110" height="219" style="margin: 10px" alt="A screenshot of Delta Chat on iOS" />
 </picture>
+</a>
+</div>
 
 [Download](https://get.delta.chat){: .cta-button}
 


### PR DESCRIPTION
Follow-up for #736

Had to move `<a>` tag out of `<picture>` and wrap everything into `<div>`. `<div>` is needed because kramdown parser does not start an HTML block when `<a>` is encountered as `<a>` tag is a span-level HTML tag: https://kramdown.gettalong.org/syntax.html#html-blocks