### PR TITLE
cleaner changelog

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -7,8 +7,8 @@ downloads: true
 ## Changelogs {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)
-* [Android](https://github.com/deltachat/deltachat-android/blob/master/CHANGELOG.md)
-* [iOS](https://github.com/deltachat/deltachat-ios/blob/master/CHANGELOG.md)
+* [Android](https://deltachat.github.io/deltachat-android/CHANGELOG#delta-chat-android-changelog)
+* [iOS](https://deltachat.github.io/deltachat-ios/CHANGELOG#delta-chat-ios-changelog)
 * [Core](https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md)
 
 The desktop versions do not require Delta Chat to be installed on a phone.


### PR DESCRIPTION
by the "sidebar" github added recently,
there is even more cluttering on the screen.

the changelogs are meant for end-users,
so better keep things simple.
also, one of the first buttons on github is "Pricing", which may be confusing := on mobile, you see barely a single change before scrolling.

before/after:

<img width="340" alt="Screenshot 2023-10-05 at 20 50 13" src="https://github.com/deltachat/deltachat-pages/assets/9800740/c1fd7f1c-f042-40c3-b321-0f20cc99dcfb"> <img width="340" alt="Screenshot 2023-10-05 at 21 25 57" src="https://github.com/deltachat/deltachat-pages/assets/9800740/84d95e49-ce5d-46ce-b0bc-e39a86cb636a">
