### PR TITLE
raise minimal ios version from 11 to 12

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -15,7 +15,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
 
 Minimal requirements:
 Android 4.1 Jelly Bean
-or iOS 11, iPhone 5s or iPad 5/Air/Mini
+or iOS 12, iPhone 5s or iPad 5/Air/Mini 2
 or Windows 7, macOS 10.11 El Capitan, Ubuntu 18.04, Fedora 29 or Debian 10
 or compatible systems.
 


### PR DESCRIPTION
this was needed to fix a recent crash, see https://github.com/deltachat/deltachat-ios/pull/1931 for reasoning

this does not affect the number of supported devices, fortunately. (the "Mini" to "Mini 2" change fixes a bug in the list, "Mini 1" from 2012 was never supported)