### PR TITLE
bump android to 1.42.3

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -1,7 +1,7 @@
 {% assign txEn = site.data.lang['en']['en'] %}
 {% assign tx = site.data.lang[page.lang][page.lang] %}
 {% assign VERSION_DESKTOP = "1.40.4" %}
-{% assign VERSION_ANDROID = "1.40.0" %}
+{% assign VERSION_ANDROID = "1.42.2" %}
 
 <div class="download-content">
     <div id="recommendation-section" hidden>

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -1,7 +1,7 @@
 {% assign txEn = site.data.lang['en']['en'] %}
 {% assign tx = site.data.lang[page.lang][page.lang] %}
 {% assign VERSION_DESKTOP = "1.40.4" %}
-{% assign VERSION_ANDROID = "1.42.2" %}
+{% assign VERSION_ANDROID = "1.42.3" %}
 
 <div class="download-content">
     <div id="recommendation-section" hidden>


### PR DESCRIPTION
this should be merged together with https://github.com/deltachat/deltachat-pages/pull/757 , cc @hpk42 

gplay and ios are also on their ways ... amazon needs to be done and fdroid needs to be tagged, but that can be done once 1.42 is really released (fdroid takes lots of time anyways ...)

EDIT: good we waited for the other stores :) meanwhile, this pr is about 1.42.3 that includes the fix for https://github.com/deltachat/deltachat-core-rust/issues/5038