### PR TITLE
FAQ item to explain disappearing messages

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -183,7 +183,7 @@ to mute a chat, use the chat's menu (Android/Desktop) or the chat's profile (iOS
   message them or write to a group they're in as well.
 
 
-### How do disappearing messages work?
+### How do disappearing messages work? {#ephemeralmsgs}
 
 You can turn on "disappearing messages"
 in the settings of a chat,
@@ -642,7 +642,7 @@ is [using chats with guaranteed end-to-end encryption](#howtoe2ee)
 and turning on disappearing messages.
 
 Guranteed end-to-end encrypted chats protect against [MITM attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)
-and turning on ["disappearing messages"](#how-do-disappearing-messages-work) deletes the messages
+and turning on ["disappearing messages"](#ephemeralmsgs) deletes the messages
 on the server after a user-configured time.
 
 If you don't need a longer-lived copy of your messages on the server, 

--- a/en/help.md
+++ b/en/help.md
@@ -603,6 +603,37 @@ even if the direct chat between you two has a
 ["… sent a message from another device"](#nocryptanymore) warning. 
 
 
+### How do disappearing messages work?
+
+You can turn on "disappearing messages"
+in the settings of a chat,
+at the top right of the chat window,
+by selecting a time span
+between 30 seconds and 5 weeks.
+
+Until the setting is turned off again,
+each chat member's Delta Chat app takes care
+of deleting the messages
+after the selected time span.
+The time span begins when the receiver's Delta Chat app
+first sees the message.
+The messages are deleted
+both in each email account on the server,
+and in the app itself.
+
+Note that you can rely on disappearing messages
+only as long as you trust your chat partners;
+malicious chat partners can screenshot
+or otherwise save a message before it is deleted.
+
+Apart from that,
+if one chat partner silently uninstalls Delta Chat,
+the messages will not get deleted from their device
+nor their email account.
+They will most likely also not be decryptable anymore
+(as long as they were encrypted in the first place).
+
+
 ### How can I ensure message end-to-end encryption and deletion?
 
 The best way to ensure every message is end-to-end encrypted,
@@ -611,7 +642,7 @@ is [using chats with guaranteed end-to-end encryption](#howtoe2ee)
 and turning on disappearing messages.
 
 Guranteed end-to-end encrypted chats protect against [MITM attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)
-and turning on "disappearing messages" deletes the messages
+and turning on ["disappearing messages"](#how-do-disappearing-messages-work) deletes the messages
 on the server after a user-configured time.
 
 If you don't need a longer-lived copy of your messages on the server, 

--- a/en/help.md
+++ b/en/help.md
@@ -627,7 +627,7 @@ malicious chat partners can screenshot
 or otherwise save a message before it is deleted.
 
 Apart from that,
-if one chat partner silently uninstalls Delta Chat,
+if one chat partner uninstalls Delta Chat,
 the messages will not get deleted from their device
 nor their email account.
 They will most likely also not be decryptable anymore

--- a/en/help.md
+++ b/en/help.md
@@ -203,8 +203,8 @@ and in the app itself.
 
 Note that you can rely on disappearing messages
 only as long as you trust your chat partners;
-malicious chat partners can screenshot
-or otherwise save a message before it is deleted.
+malicious chat partners can take photos,
+or otherwise save, copy or forward messages before deletion.
 
 Apart from that,
 if one chat partner uninstalls Delta Chat,

--- a/en/help.md
+++ b/en/help.md
@@ -208,8 +208,7 @@ or otherwise save, copy or forward messages before deletion.
 
 Apart from that,
 if one chat partner uninstalls Delta Chat,
-the messages will not get deleted from their device
-nor their email account.
+the messages will not get deleted from their email account.
 They will most likely also not be decryptable anymore
 (as long as they were encrypted in the first place).
 

--- a/en/help.md
+++ b/en/help.md
@@ -183,6 +183,37 @@ to mute a chat, use the chat's menu (Android/Desktop) or the chat's profile (iOS
   message them or write to a group they're in as well.
 
 
+### How do disappearing messages work?
+
+You can turn on "disappearing messages"
+in the settings of a chat,
+at the top right of the chat window,
+by selecting a time span
+between 30 seconds and 5 weeks.
+
+Until the setting is turned off again,
+each chat member's Delta Chat app takes care
+of deleting the messages
+after the selected time span.
+The time span begins when the receiver's Delta Chat app
+first sees the message.
+The messages are deleted
+both in each email account on the server,
+and in the app itself.
+
+Note that you can rely on disappearing messages
+only as long as you trust your chat partners;
+malicious chat partners can screenshot
+or otherwise save a message before it is deleted.
+
+Apart from that,
+if one chat partner uninstalls Delta Chat,
+the messages will not get deleted from their device
+nor their email account.
+They will most likely also not be decryptable anymore
+(as long as they were encrypted in the first place).
+
+
 ### How can I delete my account?
 
 As you use an e-mail account for Delta Chat,
@@ -601,37 +632,6 @@ and then create a guaranteed end-to-end encrypted group chat with you two as mem
 In this group chat all messages will be end-to-end encrypted 
 even if the direct chat between you two has a
 ["… sent a message from another device"](#nocryptanymore) warning. 
-
-
-### How do disappearing messages work?
-
-You can turn on "disappearing messages"
-in the settings of a chat,
-at the top right of the chat window,
-by selecting a time span
-between 30 seconds and 5 weeks.
-
-Until the setting is turned off again,
-each chat member's Delta Chat app takes care
-of deleting the messages
-after the selected time span.
-The time span begins when the receiver's Delta Chat app
-first sees the message.
-The messages are deleted
-both in each email account on the server,
-and in the app itself.
-
-Note that you can rely on disappearing messages
-only as long as you trust your chat partners;
-malicious chat partners can screenshot
-or otherwise save a message before it is deleted.
-
-Apart from that,
-if one chat partner uninstalls Delta Chat,
-the messages will not get deleted from their device
-nor their email account.
-They will most likely also not be decryptable anymore
-(as long as they were encrypted in the first place).
 
 
 ### How can I ensure message end-to-end encryption and deletion?

--- a/tools/create-local-help.py
+++ b/tools/create-local-help.py
@@ -26,9 +26,12 @@ linked_files = [
 ]
 
 # list all anchors (fragments) that are used from outside to access the help
-# ()eg. `multiclient` if the help is opened with `help#multiclient`)
+# eg. `multiclient` if the help is opened with `help#multiclient`.
+# (using a bit more cryptic/basic anchors
+# protects against renaming in UI and translation of the anchors :)
 anchors_from_external = [
     "e2eeguarantee",
+    "ephemeralmsgs",
     "howtoe2ee",
     "multiclient",
     "nocryptanymore"


### PR DESCRIPTION
It doesn't entirely fit into the "encryption" section, but as it relates to the FAQ item below it, I thought it's probably the best spot. Alternatively, "miscellaneous" would also work.

fix #762