### PR TITLE
clarify when 'ephemeral timer' really starts

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -195,8 +195,8 @@ Until the setting is turned off again,
 each chat member's Delta Chat app takes care
 of deleting the messages
 after the selected time span.
-The time span begins when the receiver's Delta Chat app
-first sees the message.
+The time span begins
+when the receiver first sees the message in Delta Chat.
 The messages are deleted
 both in each email account on the server,
 and in the app itself.


### PR DESCRIPTION
the passive wording
'begins when the receiver’s Delta Chat app first sees the message' is quite passive and could be interpreted
such as there is no user action needed at all to start the timer.

in fact, the timer starts when the _user_ first "sees" the message.

/me came over that during translating