### PR TITLE
Update PGP import documentation to match behavior

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -711,10 +711,6 @@ This is not the main goal of Delta Chat. In fact, the majority of new
 users will not have any key prior to using Delta Chat. We do, however,
 try to support private keys from as many sources as possible.
 
-If you want to keep your passphrase you'll have to create an e-mail
-alias for use with Delta Chat such that Delta Chat's key is tied to
-this e-mail alias.
-
 Removing the password from the private key will depend on the
 software you use to manage your PGP keys. With Enigmail, you can set your
 password to an empty value in the Key Management window. With GnuPG you can set

--- a/en/help.md
+++ b/en/help.md
@@ -704,8 +704,8 @@ passphrase encryption and the password and try the import again.  If you want
 to keep your passphrase you'll have to create an e-mail alias for use
 with Delta Chat such that Delta Chat's key is tied to this e-mail alias.
 
-Another common error is if your file is in the ascii armored format,
-the file must have an `.asc` file ending.
+Another common error is having the wrong file ending. If your file is
+in the ASCII armored format the file must have an `.asc` file ending.
 
 Delta Chat supports common OpenPGP private key formats, however, it
 is unlikely that private keys from all sources will be fully supported. This

--- a/en/help.md
+++ b/en/help.md
@@ -700,18 +700,20 @@ If you don't have a key or don't even know you would need one - don't worry: Del
 
 The most likely cause is that your key is encrypted and/or uses
 a password. Such keys are not supported by Delta Chat.  You could remove the
-passphrase encryption and the password and try the import again.  If you want
-to keep your passphrase you'll have to create an e-mail alias for use
-with Delta Chat such that Delta Chat's key is tied to this e-mail alias.
+passphrase encryption and the password and try the import again.
 
-Another common error is having the wrong file ending. If your file is
-in the ASCII armored format the file must have an `.asc` file ending.
+Another common error is having the wrong file ending. Use the ASCII
+armored format and an `.asc` file ending.
 
-Delta Chat supports common OpenPGP private key formats, however, it
-is unlikely that private keys from all sources will be fully supported. This
-is not the main goal of Delta Chat. In fact, the majority of new users 
-will not have any key prior to using Delta Chat.
-We do, however, try to support private keys from as many sources as possible. 
+Delta Chat supports common OpenPGP private key formats, however, it is
+unlikely that private keys from all sources will be fully supported.
+This is not the main goal of Delta Chat. In fact, the majority of new
+users will not have any key prior to using Delta Chat. We do, however,
+try to support private keys from as many sources as possible.
+
+If you want to keep your passphrase you'll have to create an e-mail
+alias for use with Delta Chat such that Delta Chat's key is tied to
+this e-mail alias.
 
 Removing the password from the private key will depend on the
 software you use to manage your PGP keys. With Enigmail, you can set your
@@ -719,7 +721,6 @@ password to an empty value in the Key Management window. With GnuPG you can set
 it [via the command
 line](https://github.com/deltachat/deltachat-android/issues/98#issuecomment-378383429).
 For other programs, you should be able to find a solution online.
-
 
 ## Multi-client {#multiclient}
 

--- a/en/help.md
+++ b/en/help.md
@@ -704,6 +704,9 @@ passphrase encryption and the password and try the import again.  If you want
 to keep your passphrase you'll have to create an e-mail alias for use
 with Delta Chat such that Delta Chat's key is tied to this e-mail alias.
 
+Another common error is if your file is in the ascii armored format,
+the file must have an `.asc` file ending.
+
 Delta Chat supports common OpenPGP private key formats, however, it
 is unlikely that private keys from all sources will be fully supported. This
 is not the main goal of Delta Chat. In fact, the majority of new users 


### PR DESCRIPTION
Alternatively, someone could fix this behavior in the app so it could
autodetect keys regardless of file endings. But then it'd have to
scan every file.
