### PR TITLE
the minimum for 'disappearing messages' seems to be 1 minute

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -189,7 +189,7 @@ You can turn on "disappearing messages"
 in the settings of a chat,
 at the top right of the chat window,
 by selecting a time span
-between 30 seconds and 5 weeks.
+between 1 minute and 5 weeks.
 
 Until the setting is turned off again,
 each chat member's Delta Chat app takes care


### PR DESCRIPTION
i checked recent android/desktop/ios - all "1 minute" as minimum.

@missytake where do the "30 seconds" come from?