### PR TITLE
Revert "hide windows store button because it is broken"

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -88,11 +88,9 @@
         <div class="box" id="windows">
             <div class="title">Windows</div>
             <div class="buttons">
-                <!-- windows store release is currently broken, see https://github.com/deltachat/deltachat-desktop/issues/3292
                 <a href="https://www.microsoft.com/en-us/p/deltachat/9pjtxx7hn3pk?activetab=pivot:overviewtab" class="img-badge">
                     <img src="../assets/badges/microsoft.svg" alt="{%if tx.download.dl_microsoft != ""%}{{ tx.download.dl_microsoft }}{%else%}{{ txEn.download.dl_microsoft }}{%endif%}" width=133 height=48 />
                 </a>
-                -->
                 <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat%20Setup%20{{VERSION_DESKTOP}}.exe"><small>Download</small> Setup.exe</a>
             </div>
             <div class="descr">


### PR DESCRIPTION
This reverts commit 7b644f17b2ba42cbfe299b50481e77ab6ec3eaf4.

as far as i followed things, windows store seems to be up and available again