### PR TITLE
simplify year bumping chore

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,5 +178,3 @@ License
 --------------------------------------------------------------------------------
 
 Licensed GPLv3+, see the LICENSE file for details.
-
-Copyright © 2021 Delta Chat contributors

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -86,7 +86,7 @@
 <p>
 {% include subscribe-to-feed-links.html %}
 <br>
-© 2024 Delta Chat contributors
+© 2024 Delta Chat contributors <!-- when bumping year, see also .well-known/security.txt -->
 </p>
 </div>
 


### PR DESCRIPTION
- remove year from README, usually we do not have a year there

- add a hint to .well-known/security.txt to the visible copyright-year