### PR TITLE
Add nine.testrun.org QR invite to download page

### DIFF
--- a/_data/lang/ca.yml
+++ b/_data/lang/ca.yml
@@ -22,8 +22,12 @@ ca:
   language: Idioma
 
   download:
-    recommendation: Recomanat per a tu
-    other: Altres plataformes
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Codi font
     install_via_packagemanager: Instal·la'l via Gestor de Paquets
     outdated: desactualitzat

--- a/_data/lang/cs.yml
+++ b/_data/lang/cs.yml
@@ -22,8 +22,12 @@ cs:
   language: Jazyk
 
   download:
-    recommendation: Doporučujeme
-    other: Jíné technologie
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Zdrojový kód
     install_via_packagemanager: Instalace ze správce balíčků
     outdated: zastaralé

--- a/_data/lang/de.yml
+++ b/_data/lang/de.yml
@@ -22,8 +22,12 @@ de:
   language: Sprache
 
   download:
-    recommendation: Für Sie empfohlen
-    other: Andere Plattformen
+    install: Delta Chat installieren
+    get_account: Ein Konto einrichten
+    get_account_explanation: "Sie können (fast) jedes E-Mail-Konto für Delta Chat verwenden. Wenn Sie ein neues Konto benötigen, tippen oder scannen Sie den folgenden QR-Code um eine zufällige E-Mail-Adresse auf <a href=\"https://nine.testrun.org\" target=\"_blank\">@nine.testrun.org</a> zu erhalten"
+    add_friends: Einen Namen eingeben und Freunde treffen
+    add_friends_explanation: "Jetzt können Sie einen Benutzernamen eingeben, ein Profilbild auswählen und mit Ihren Freunden chatten. Am Besten triffst du sie und scannst ihren <a href=\"help#howtoe2ee\">QR-Code</a>."
+    other: Download-Optionen für andere Plattformen
     source_code: Quellcode
     install_via_packagemanager: Über Paketmanager installieren
     outdated: veraltet

--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -25,8 +25,10 @@ en:
     install: Step 1 - Install Delta Chat
     get_account: Step 2 - Get an Account
     get_account_explanation: You can use (almost) any email account with Delta Chat. If you need a new one, tap or scan this QR code to get a random <a href="https://nine.testrun.org" target="_blank">@nine.testrun.org</a> email address
+    add_friends: Step 3 - Enter a Username and Meet Your Friends
+    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. The best way is to meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a>.
     recommendation: Recommended for you
-    other: Expand to see other platforms
+    other: Expand to see download options for other platforms
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager
     outdated: outdated

--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -22,13 +22,12 @@ en:
   language: Language
 
   download:
-    install: Step 1 - Install Delta Chat
-    get_account: Step 2 - Get an Account
+    install: Install Delta Chat
+    get_account: Get an Account
     get_account_explanation: You can use (almost) any email account with Delta Chat. If you need a new one, tap or scan this QR code to get a random <a href="https://nine.testrun.org" target="_blank">@nine.testrun.org</a> email address
-    add_friends: Step 3 - Enter a Username and Meet Your Friends
+    add_friends: Enter a Username and Meet Your Friends
     add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. The best way is to meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a>.
-    recommendation: Recommended for you
-    other: Expand to see download options for other platforms
+    other: Download options for other platforms
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager
     outdated: outdated

--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -22,8 +22,11 @@ en:
   language: Language
 
   download:
+    install: Step 1 - Install Delta Chat
+    get_account: Step 2 - Get an Account
+    get_account_explanation: You can use (almost) any email account with Delta Chat. If you need a new one, tap or scan this QR code to get a random <a href="https://nine.testrun.org" target="_blank">@nine.testrun.org</a> email address
     recommendation: Recommended for you
-    other: Other platforms
+    other: Expand to see other platforms
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager
     outdated: outdated

--- a/_data/lang/es.yml
+++ b/_data/lang/es.yml
@@ -22,8 +22,12 @@ es:
   language: Idioma
 
   download:
-    recommendation: Recomendado para ti
-    other: Otras plataformas
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Código Fuente
     install_via_packagemanager: Instalar a través del Administrador de Paquetes
     outdated: desactualizado

--- a/_data/lang/fr.yml
+++ b/_data/lang/fr.yml
@@ -22,8 +22,12 @@ fr:
   language: Langue
 
   download:
-    recommendation: Recommandé pour vous
-    other: Autres plateformes
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Code source
     install_via_packagemanager: Installation via le gestionnaire de paquets
     outdated: dépassé

--- a/_data/lang/gl.yml
+++ b/_data/lang/gl.yml
@@ -22,8 +22,12 @@ gl:
   language: Idioma
 
   download:
-    recommendation: Recomendado para ti
-    other: Outras plataformas
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Código Fonte
     install_via_packagemanager: Instalar vía Xestor de Paquetes
     outdated: antigo

--- a/_data/lang/id.yml
+++ b/_data/lang/id.yml
@@ -22,8 +22,12 @@ id:
   language: Bahasa
 
   download:
-    recommendation: Direkomendasikan untukmu
-    other: Platform lainnya
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Source Code
     install_via_packagemanager: Instal melalui Package Manager
     outdated: ketinggalan jaman

--- a/_data/lang/it.yml
+++ b/_data/lang/it.yml
@@ -22,8 +22,12 @@ it:
   language: Lingua
 
   download:
-    recommendation: Consigliati per te
-    other: Altre piattaforme
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Codice sorgente
     install_via_packagemanager: Installa tramite Package Manager
     outdated: obsoleto

--- a/_data/lang/nl.yml
+++ b/_data/lang/nl.yml
@@ -22,8 +22,12 @@ nl:
   language: Taal
 
   download:
-    recommendation: Aanbeveling
-    other: Andere besturingssystemen
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Broncode
     install_via_packagemanager: Installeren via pakketbeheerder
     outdated: verouderd

--- a/_data/lang/pl.yml
+++ b/_data/lang/pl.yml
@@ -22,8 +22,12 @@ pl:
   language: Język
 
   download:
-    recommendation: Polecany dla Ciebie
-    other: Inne platformy
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Kod źródłowy
     install_via_packagemanager: Zainstaluj za pomocą Menedżera pakietów
     outdated: przestarzały

--- a/_data/lang/pt.yml
+++ b/_data/lang/pt.yml
@@ -22,8 +22,12 @@ pt:
   language: Língua
 
   download:
-    recommendation: Recommended for you
-    other: Other platforms
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager
     outdated: outdated

--- a/_data/lang/pt_BR.yml
+++ b/_data/lang/pt_BR.yml
@@ -22,8 +22,12 @@ pt_BR:
   language: Língua
 
   download:
-    recommendation: Recommended for you
-    other: Other platforms
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager
     outdated: outdated

--- a/_data/lang/ru.yml
+++ b/_data/lang/ru.yml
@@ -22,8 +22,12 @@ ru:
   language: Язык
 
   download:
-    recommendation: Рекомендуется для вас
-    other: Другие платформы
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Исходный код
     install_via_packagemanager: Установка через Диспетчер пакетов
     outdated: устаревшее

--- a/_data/lang/sk.yml
+++ b/_data/lang/sk.yml
@@ -22,8 +22,12 @@ sk:
   language: Jazyk
 
   download:
-    recommendation: Odporúčané pre vás
-    other: Iné platformy
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: "Zdrojový kód "
     install_via_packagemanager: Nainštalujte pomocou Package Manager
     outdated: zastarané

--- a/_data/lang/sq.yml
+++ b/_data/lang/sq.yml
@@ -22,8 +22,12 @@ sq:
   language: Gjuhë
 
   download:
-    recommendation: Këshilluar për ju
-    other: Platforma të tjera
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Kod Burim
     install_via_packagemanager: Instalojeni përmes Përgjegjësi Paketash
     outdated: e vjetruar

--- a/_data/lang/tr.yml
+++ b/_data/lang/tr.yml
@@ -22,8 +22,12 @@ tr:
   language: Dil
 
   download:
-    recommendation: Sizin için öneriliyor
-    other: Diğer platformlar
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Kaynak Kodu
     install_via_packagemanager: Paket Yöneticisi Yoluyla Kur
     outdated: eski

--- a/_data/lang/uk.yml
+++ b/_data/lang/uk.yml
@@ -22,8 +22,12 @@ uk:
   language: Мова
 
   download:
-    recommendation: Рекомендовано для вас
-    other: Інші платформи
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: Вихідний код
     install_via_packagemanager: Інсталювати через пакетний менеджер
     outdated: застаріло

--- a/_data/lang/zh_CN.yml
+++ b/_data/lang/zh_CN.yml
@@ -22,8 +22,12 @@ zh_CN:
   language: 语言
 
   download:
-    recommendation: 为您推荐
-    other: 其他平台
+    install: ""
+    get_account: ""
+    get_account_explanation: ""
+    add_friends: ""
+    add_friends_explanation: ""
+    other: ""
     source_code: 源代码
     install_via_packagemanager: 通过包管理器安装
     outdated: 过时的

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -4,13 +4,14 @@
 {% assign VERSION_ANDROID = "1.42.6" %}
 
 <div class="download-content">
+    <h1>{%if tx.download.install != ""%}{{ tx.download.install }}{%else%}{{ txEn.download.install }}{%endif%}:</h1>
     <div id="recommendation-section" hidden>
-        <h1>{%if tx.download.recommendation != ""%}{{ tx.download.recommendation }}{%else%}{{ txEn.download.recommendation }}{%endif%}</h1>
+        <p><b>{%if tx.download.recommendation != ""%}{{ tx.download.recommendation }}{%else%}{{ txEn.download.recommendation }}{%endif%}:</b></p>
         <div id="recommend"></div>
-        <h1>{%if tx.download.other != ""%}{{ tx.download.other }}{%else%}{{ txEn.download.other }}{%endif%}</h1>
     </div>
-    <h1 id="noscript-headline">{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</h1>
-    <div id="boxes">
+    <h2 id="noscript-headline">{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</h2>
+    <details id="boxes">
+        <summary><b>{%if tx.download.other != ""%}{{ tx.download.other }}{%else%}{{ txEn.download.other }}{%endif%}</b></summary>
         <div class="box" id="android">
             <div class="title">Android</div>
             <div class="buttons">
@@ -142,6 +143,13 @@
                 See <a href="https://delta.chat/en/2023-07-02-deltatouch">blog</a> for details about this community driven effort
             </div>
         </div>
-    </div>
+    </details>
+    <h2>{%if tx.download.get_account != ""%}{{ tx.download.get_account }}{%else%}{{ txEn.download.get_account }}{%endif%}:</h2>
+    <p>{%if tx.download.get_account_explanation != ""%}{{ tx.download.get_account_explanation }}{%else%}{{ txEn.download.get_account_explanation }}{%endif%}:</p>
+    <p>
+        <a href="dcaccount:https://nine.testrun.org/cgi-bin/newemail.py">
+            <img width="300" style="float:none;" src="../assets/blog/nine-invite-qrcode.png">
+        </a>
+    </p>
 </div>
 <script src="../assets/js/download-page2.js"></script>

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -4,12 +4,11 @@
 {% assign VERSION_ANDROID = "1.42.6" %}
 
 <div class="download-content">
-    <h1>{%if tx.download.install != ""%}{{ tx.download.install }}{%else%}{{ txEn.download.install }}{%endif%}:</h1>
+    <h1>❶ {%if tx.download.install != ""%}{{ tx.download.install }}{%else%}{{ txEn.download.install }}{%endif%}</h1>
     <div id="recommendation-section" hidden>
-        <p><b>{%if tx.download.recommendation != ""%}{{ tx.download.recommendation }}{%else%}{{ txEn.download.recommendation }}{%endif%}:</b></p>
         <div id="recommend"></div>
     </div>
-    <h2 id="noscript-headline">{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</h2>
+    <h2 id="noscript-headline">❶ {%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</h2>
     <details id="boxes">
         <summary><b>{%if tx.download.other != ""%}{{ tx.download.other }}{%else%}{{ txEn.download.other }}{%endif%}</b></summary>
         <div class="box" id="android">
@@ -144,14 +143,14 @@
             </div>
         </div>
     </details>
-    <h2>{%if tx.download.get_account != ""%}{{ tx.download.get_account }}{%else%}{{ txEn.download.get_account }}{%endif%}:</h2>
+    <h2>❷ {%if tx.download.get_account != ""%}{{ tx.download.get_account }}{%else%}{{ txEn.download.get_account }}{%endif%}</h2>
     <p>{%if tx.download.get_account_explanation != ""%}{{ tx.download.get_account_explanation }}{%else%}{{ txEn.download.get_account_explanation }}{%endif%}:</p>
     <p>
         <a href="dcaccount:https://nine.testrun.org/cgi-bin/newemail.py">
             <img width="300" style="float:none;" src="../assets/blog/nine-invite-qrcode.png">
         </a>
     </p>
-    <h2>{%if tx.download.add_friends != ""%}{{ tx.download.add_friends }}{%else%}{{ txEn.download.add_friends }}{%endif%}:</h2>
+    <h2>❸ {%if tx.download.add_friends != ""%}{{ tx.download.add_friends }}{%else%}{{ txEn.download.add_friends }}{%endif%}</h2>
     <p>{%if tx.download.add_friends_explanation != ""%}{{ tx.download.add_friends_explanation }}{%else%}{{ txEn.download.add_friends_explanation }}{%endif%}</p>
 </div>
 <script src="../assets/js/download-page2.js"></script>

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -151,5 +151,7 @@
             <img width="300" style="float:none;" src="../assets/blog/nine-invite-qrcode.png">
         </a>
     </p>
+    <h2>{%if tx.download.add_friends != ""%}{{ tx.download.add_friends }}{%else%}{{ txEn.download.add_friends }}{%endif%}:</h2>
+    <p>{%if tx.download.add_friends_explanation != ""%}{{ tx.download.add_friends_explanation }}{%else%}{{ txEn.download.add_friends_explanation }}{%endif%}</p>
 </div>
 <script src="../assets/js/download-page2.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,11 +28,11 @@
 <ul>
 <li aria-hidden="true"><a href="../{{page.lang}}/"><img src="../assets/logos/delta-chat.svg" width="32" height="32" style="position: relative; bottom: -3px;" /></a></li>
 <li><a href="../{{page.lang}}/">{%if tx.menu.home != ""%}{{ tx.menu.home }}{%else%}{{ txEn.menu.home }}{%endif%}</a></li>
-<li><a href="download">{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</a></li>
 <li><a href="blog">{%if tx.menu.blog != ""%}{{ tx.menu.blog }}{%else%}{{ txEn.menu.blog }}{%endif%}</a></li>
 <li><a href="contribute">{%if tx.menu.contribute != ""%}{{ tx.menu.contribute }}{%else%}{{ txEn.menu.contribute }}{%endif%}</a></li>
 <li><a href="help">{%if tx.menu.help != ""%}{{ tx.menu.help }}{%else%}{{ txEn.menu.help }}{%endif%}</a></li>
 <li><a href="https://support.delta.chat">{%if tx.menu.forum != ""%}{{ tx.menu.forum }}{%else%}{{ txEn.menu.forum }}{%endif%}</a></li>
+<li><a class="cta-button" href="download">{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</a></li>
 </ul>
 </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,11 +28,11 @@
 <ul>
 <li aria-hidden="true"><a href="../{{page.lang}}/"><img src="../assets/logos/delta-chat.svg" width="32" height="32" style="position: relative; bottom: -3px;" /></a></li>
 <li><a href="../{{page.lang}}/">{%if tx.menu.home != ""%}{{ tx.menu.home }}{%else%}{{ txEn.menu.home }}{%endif%}</a></li>
+<li><a href="download">{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</a></li>
 <li><a href="blog">{%if tx.menu.blog != ""%}{{ tx.menu.blog }}{%else%}{{ txEn.menu.blog }}{%endif%}</a></li>
 <li><a href="contribute">{%if tx.menu.contribute != ""%}{{ tx.menu.contribute }}{%else%}{{ txEn.menu.contribute }}{%endif%}</a></li>
 <li><a href="help">{%if tx.menu.help != ""%}{{ tx.menu.help }}{%else%}{{ txEn.menu.help }}{%endif%}</a></li>
 <li><a href="https://support.delta.chat">{%if tx.menu.forum != ""%}{{ tx.menu.forum }}{%else%}{{ txEn.menu.forum }}{%endif%}</a></li>
-<li><a class="cta-button" href="download">{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</a></li>
 </ul>
 </div>
 

--- a/ca/download.md
+++ b/ca/download.md
@@ -4,6 +4,8 @@ lang: ca
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Registre de canvis {#changelogs}
 
 * [Escriptori](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/cs/download.md
+++ b/cs/download.md
@@ -4,6 +4,8 @@ lang: cs
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Záznam o změnách {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/de/download.md
+++ b/de/download.md
@@ -4,6 +4,8 @@ lang: de
 downloads: true
 ---
 
+![Ein iOS-Benutzer scannt einen QR-Code auf dem Telefon einer anderen Person.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Änderungsprotokolle {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/en/download.md
+++ b/en/download.md
@@ -4,6 +4,8 @@ lang: en
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Changelogs {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/es/download.md
+++ b/es/download.md
@@ -4,6 +4,8 @@ lang: es
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Registro de cambios {#changelogs}
 
 * [Escritorio](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/fr/download.md
+++ b/fr/download.md
@@ -4,6 +4,8 @@ lang: fr
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Journal des modifications {#changelogs}
 
 * [PC](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/gl/download.md
+++ b/gl/download.md
@@ -4,6 +4,8 @@ lang: gl
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Rexistro de cambios {#changelogs}
 
 * [Escritorio](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/id/download.md
+++ b/id/download.md
@@ -4,6 +4,8 @@ lang: id
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Log perubahan {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/it/download.md
+++ b/it/download.md
@@ -4,6 +4,8 @@ lang: it
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Changelog {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/nl/download.md
+++ b/nl/download.md
@@ -4,6 +4,8 @@ lang: nl
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Wijzigingslogs (Engels) {#changelogs}
 
 * [Computer](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/pl/download.md
+++ b/pl/download.md
@@ -4,6 +4,8 @@ lang: pl
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Rejestr zmian {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/pt/download.md
+++ b/pt/download.md
@@ -4,6 +4,8 @@ lang: pt
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Registro de alterações {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/pt_BR/download.md
+++ b/pt_BR/download.md
@@ -4,6 +4,8 @@ lang: pt_BR
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Registro de alterações {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/ru/download.md
+++ b/ru/download.md
@@ -4,6 +4,8 @@ lang: ru
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Список изменений {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/sk/download.md
+++ b/sk/download.md
@@ -4,6 +4,8 @@ lang: sk
 downloads: true 
 --- 
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Denníky zmien {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/sq/download.md
+++ b/sq/download.md
@@ -4,6 +4,8 @@ lang: sq
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Regjistra ndryshimesh {#changelogs}
 
 * [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/tr/download.md
+++ b/tr/download.md
@@ -4,6 +4,8 @@ lang: tr
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Değişiklik Günlükleri {#changelogs}
 
 * [Masaüstü](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/uk/download.md
+++ b/uk/download.md
@@ -4,6 +4,8 @@ lang: uk
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## Список змін {#changelogs}
 
 * [Комп'ютер](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)

--- a/zh_CN/download.md
+++ b/zh_CN/download.md
@@ -4,6 +4,8 @@ lang: zh_CN
 downloads: true
 ---
 
+![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
+
 ## 变更日志 {#changelogs}
 
 * [桌面版](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)


### PR DESCRIPTION
In other languages than english it doesn't work yet; the new strings on the download page remain empty, I don't understand why. Any ideas? I tried to do transifex magic, but tx init fails for me because api.transifex.com isn't reachable o.0

This could be prettier, but good enough for now. I'm not a designer.