### PR TITLE
explain chatmail unencrypted restriction on get.delta.chat

### DIFF
--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -23,10 +23,6 @@ en:
 
   download:
     install: Install Delta Chat
-    get_account: Get an Account
-    get_account_explanation: You can use (almost) any email account with Delta Chat. If you need a new one, tap or scan this QR code to get a random <a href="https://nine.testrun.org" target="_blank">@nine.testrun.org</a> email address
-    add_friends: Enter a Username and Meet Your Friends
-    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. <b>NOTE:</b> with a <a href="https://nine.testrun.org/info.html">@nine.testrun.org</a> account you can't send unencrypted messages to users on other servers; meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a> or ask them to send a message to you first.
     other: Download options for other platforms
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager

--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -26,7 +26,7 @@ en:
     get_account: Get an Account
     get_account_explanation: You can use (almost) any email account with Delta Chat. If you need a new one, tap or scan this QR code to get a random <a href="https://nine.testrun.org" target="_blank">@nine.testrun.org</a> email address
     add_friends: Enter a Username and Meet Your Friends
-    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. The best way is to meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a>.
+    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. <b>NOTE:</b> with a <a href="https://nine.testrun.org/info.html">@nine.testrun.org</a> account you can't send unencrypted messages to users on other servers; meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a> or ask them to send a message to you first.
     other: Download options for other platforms
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -142,14 +142,5 @@
             </div>
         </div>
     </details>
-    <h2>❷ {%if tx.download.get_account != ""%}{{ tx.download.get_account }}{%else%}{{ txEn.download.get_account }}{%endif%}</h2>
-    <p>{%if tx.download.get_account_explanation != ""%}{{ tx.download.get_account_explanation }}{%else%}{{ txEn.download.get_account_explanation }}{%endif%}:</p>
-    <p>
-        <a href="dcaccount:https://nine.testrun.org/cgi-bin/newemail.py">
-            <img width="300" style="float:none;" src="../assets/blog/nine-invite-qrcode.png">
-        </a>
-    </p>
-    <h2>❸ {%if tx.download.add_friends != ""%}{{ tx.download.add_friends }}{%else%}{{ txEn.download.add_friends }}{%endif%}</h2>
-    <p>{%if tx.download.add_friends_explanation != ""%}{{ tx.download.add_friends_explanation }}{%else%}{{ txEn.download.add_friends_explanation }}{%endif%}</p>
 </div>
 <script src="../assets/js/download-page2.js"></script>

--- a/en/download.md
+++ b/en/download.md
@@ -4,6 +4,26 @@ lang: en
 downloads: true
 ---
 
+## ❷ Get an Account
+
+You can use (almost) any email account with Delta Chat.
+If you need a new one,
+tap or scan this QR code
+to get a random [@nine.testrun.org](https://nine.testrun.org) email address:
+
+[![dcaccount:https://nine.testrun.org/cgi-bin/newemail.py](../assets/blog/nine-invite-qrcode.png)](dcaccount:https://nine.testrun.org/cgi-bin/newemail.py)
+
+## ❸ Enter a Username and Meet Your Friends
+
+Now you can enter a username,
+select a profile picture,
+and chat with your friends.
+**NOTE:** with a [@nine.testrun.org](https://nine.testrun.org/info.html) account
+you can't send unencrypted messages
+to users on other servers;
+meet them and verify them by [scanning QR codes](help#howtoe2ee)
+or ask them to send a message to you first.
+
 ![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
 
 ## Changelogs {#changelogs}

--- a/en/download.md
+++ b/en/download.md
@@ -6,7 +6,7 @@ downloads: true
 
 ## ❷ Get an Account
 
-You can use (almost) any email account with Delta Chat.
+You can use [(almost)](https://providers.delta.chat/) any email account with Delta Chat.
 If you need a new one,
 tap or scan this QR code
 to get a random [@nine.testrun.org](https://nine.testrun.org) email address:


### PR DESCRIPTION
Until the error is explained nicely in the app, we should have some explanation on the download page - many users will probably still miss it (many users will probably not realize they can click on the QR code, there are still some things you need to know so this works)