### PR TITLE
improve add-second-device troubleshooting for windows

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -753,6 +753,9 @@ One device is not needed for the other to work.
   which is known to cause problems (especially on Windows).
   **Disable the personal firewall** for Delta Chat on both ends and try again
 
+- **Guest Networks** may not allow devices to communicate with each other.
+  If possible, use a non-guest network.
+
 - Ensure there is **enough storage** on the destination device
 
 - If transfer started, make sure, the devices **stay active** and do not fall asleep.

--- a/en/help.md
+++ b/en/help.md
@@ -747,6 +747,7 @@ One device is not needed for the other to work.
 
 - On **Windows**, go to **Control Panel / Network and Internet**
   and make sure, **Private Network** is selected as "Network profile type"
+  (after transfer, you can change back to the original value)
 
 - Your system might have a "personal firewall",
   which is known to cause problems (especially on Windows).

--- a/en/help.md
+++ b/en/help.md
@@ -745,6 +745,9 @@ One device is not needed for the other to work.
 
 - Double-check both devices are in the **same Wi-Fi or network**
 
+- On **Windows**, go to **Control Panel / Network and Internet**
+  and make sure, **Private Network** is selected as "Network profile type"
+
 - Your system might have a "personal firewall",
   which is known to cause problems (especially on Windows).
   **Disable the personal firewall** for Delta Chat on both ends and try again


### PR DESCRIPTION
explicitly mention to switch to 'Private Network' on windows add-second-device troubleshooting, could not check on an english windows, but searching for the terms, these seems to be the wordings used by windows

i moved the point to the second-option, directly after same-network, as it seems to be a pretty concrete issue on windows.

closes https://support.delta.chat/t/add-hint-select-on-windows-desktop-private-network-to-add-a-second-device/2921
closes https://github.com/deltachat/deltachat-desktop/issues/3218

this will also go to the offline helps once merged.