### PR TITLE
update minimal macOS requirements due to electron update

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -18,7 +18,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
 Minimal requirements:
 Android 4.1 Jelly Bean
 or iOS 12, iPhone 5s or iPad 5/Air/Mini 2
-or Windows 7, macOS 10.11 El Capitan, Ubuntu 18.04, Fedora 29 or Debian 10
+or Windows 7, macOS 10.15 Catalina, Ubuntu 18.04, Fedora 29 or Debian 10
 or compatible systems.
 
 ## Links

--- a/en/download.md
+++ b/en/download.md
@@ -18,7 +18,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
 Minimal requirements:
 Android 4.1 Jelly Bean
 or iOS 12, iPhone 5s or iPad 5/Air/Mini 2
-or Windows 7, macOS 10.15 Catalina, Ubuntu 18.04, Fedora 29 or Debian 10
+or Windows 10, macOS 10.15 Catalina, Ubuntu 18.04, Fedora 29 or Debian 10
 or compatible systems.
 
 ## Links


### PR DESCRIPTION
this OR updates minimal macOS requirements

according to https://support.delta.chat/t/help-testing-the-upcoming-v1-43-x-release/2940 , Delta Chat 1.43 and later will require at least macOS 10.15 (Catalina) instead of 10.11 

ftr, according to wikipedia ([[1]](https://en.wikipedia.org/wiki/OS_X_El_Capitan), [[2]](https://en.wikipedia.org/wiki/MacOS_Catalina)) this update cuts ~5 years of supported devices; oldest supported is now ~2012  instead of ~2007 - just saying, looks reasonable

@adzialocha @Simon-Laux are the versions mentioned for the systems are still up to date? (last update was https://github.com/deltachat/deltachat-pages/pull/682)