### PR TITLE
update `keytool` example command

### DIFF
--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -14,5 +14,5 @@ For Android, you can verify the signing certificate on the APK matches one of th
   `{% include fingerprint-local %}`
 
 To print the SHA256 fingerprints of the APK signing certificate you can use eg.  
-`keytool -list -printcert -jarfile <APK-file>`
+`keytool -printcert -jarfile <APK-file>`
 


### PR DESCRIPTION
using `-list` and `-printcert` at the same time just prints "keytool error: java.lang.Exception: Only one command is allowed: both -list and -printcert were specified."

and also according to
https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html , these commands seem mutually exclusive.

came over that when checking https://support.delta.chat/t/allow-the-users-to-verify-the-downloads-for-desktop/2953