### PR TITLE
download: mention invite links

### DIFF
--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -26,7 +26,7 @@ en:
     get_account: Get an Account
     get_account_explanation: You can use (almost) any email account with Delta Chat. If you need a new one, tap or scan this QR code to get a random <a href="https://nine.testrun.org" target="_blank">@nine.testrun.org</a> email address
     add_friends: Enter a Username and Meet Your Friends
-    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. The best way is to meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a>.
+    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. The best way is to <a href="../en/2024-03-12-jumbo44#sharing-invite-links-for-chats-and-chat-groups">send them an invite link</a> or meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a>.
     other: Download options for other platforms
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager

--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -26,7 +26,7 @@ en:
     get_account: Get an Account
     get_account_explanation: You can use (almost) any email account with Delta Chat. If you need a new one, tap or scan this QR code to get a random <a href="https://nine.testrun.org" target="_blank">@nine.testrun.org</a> email address
     add_friends: Enter a Username and Meet Your Friends
-    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. The best way is to <a href="../en/2024-03-12-jumbo44#sharing-invite-links-for-chats-and-chat-groups">send them an invite link</a> or meet them and verify them by <a href="help#howtoe2ee">scanning QR codes</a>.
+    add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. Meet and verify them by <a href="help#howtoe2ee">scanning QR codes</a> or <a href="../en/2024-03-12-jumbo44#sharing-invite-links-for-chats-and-chat-groups">send them an invite link</a>.
     other: Download options for other platforms
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager


### PR DESCRIPTION
This is much easier for most users than scanning QR codes.

Maybe we could also leave out scanning QR codes here, and change the image so users can see how they can create an invite link.