### PR TITLE
some space left/right of <code>

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -196,6 +196,12 @@ code, pre, blockquote { background-color: #eee; overflow-x: scroll;}
 pre, blockquote { padding: 2px 1em; }
 blockquote { font-style: italic; }
 
+code {
+    padding-left: 5px;
+    padding-right: 5px;
+    border-radius: 5px;
+}
+
 
 #content table td, #content table th { border: 1px solid #ccc; padding: 0.2em 0.4em; }
 #content table th { background-color: #eee; font-weight: bold; }


### PR DESCRIPTION
the latest blog post has quite some `<code>` parts
that look a squeezed and not really elegant.

this PR adds some more space,
allowing code to breathe :)

before/after:

![Screenshot 2024-03-25 at 16 10 16](https://github.com/deltachat/deltachat-pages/assets/9800740/7c0ced2d-8f8a-43ae-9274-a6082022c148)

---

![Screenshot 2024-03-25 at 16 09 41](https://github.com/deltachat/deltachat-pages/assets/9800740/1794d667-6280-425f-9b8a-3d6372084ba1)
