### PR TITLE
download: recommend to install flatpak with --user

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -126,7 +126,7 @@
             <div class="descr">
                 <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
                 <br />
-                Flatpak manual install: <code>flatpak install flathub chat.delta.desktop</code><br />
+                Flatpak manual install: <code>flatpak --user install flathub chat.delta.desktop</code><br />
                 Arch manual install: <code>yay -S deltachat-desktop-git</code><br />
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code>


### PR DESCRIPTION
The issue was brought up at https://support.delta.chat/t/deltachat-flatpak-not-opening-file-manager-to-allow-attaching-images-or-files/3001 - until it's fixed maybe we should recommend `--user` instead.