### PR TITLE
download: hide non-automatic download options behind <details>

### DIFF
--- a/_data/lang/en.yaml
+++ b/_data/lang/en.yaml
@@ -28,6 +28,7 @@ en:
     add_friends: Enter a Username and Meet Your Friends
     add_friends_explanation: Now you can enter a username, select a profile picture, and chat with your friends. Meet and verify them by <a href="help#howtoe2ee">scanning QR codes</a> or <a href="../en/2024-03-12-jumbo44#sharing-invite-links-for-chats-and-chat-groups">send them an invite link</a>.
     other: Download options for other platforms
+    no_upgrades: Download options without automatic updates
     source_code: Source Code
     install_via_packagemanager: Install via Package Manager
     outdated: outdated

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -53,8 +53,8 @@
                 <a href="https://github.com/deltachat/deltachat-android">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
             </div>
             <details>
-                <summary>
-                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                <summary class="noupgrades">
+                    {%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}
                 </summary>
                 <div class="buttons">
                     <a href="https://www.apklis.cu/application/chat.delta" class="img-badge">
@@ -97,8 +97,8 @@
                 Homebrew manual install: <code>brew install --cask deltachat</code>
             </div>
             <details>
-                <summary>
-                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                <summary class="noupgrades">
+                    {%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}
                 </summary>
                 <div class="buttons">
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.dmg"><small>Download</small> DeltaChat.dmg</a>
@@ -118,8 +118,8 @@
                 Winget install: <code>winget install 9PJTXX7HN3PK</code>
             </div>
             <details>
-                <summary>
-                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                <summary class="noupgrades">
+                    {%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}
                 </summary>
                 <div class="buttons">
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat%20Setup%20{{VERSION_DESKTOP}}.exe"><small>Download</small> Setup.exe</a>
@@ -150,8 +150,8 @@
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code>
             </div>
             <details>
-                <summary>
-                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                <summary class="noupgrades">
+                    {%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}
                 </summary>
                 <div class="buttons">
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop_{{VERSION_DESKTOP}}_amd64.deb"><small>Get .deb for</small> Debian/Ubuntu</a>

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -34,13 +34,6 @@
                       <img src="../assets/badges/get-it-on-paskoocheh.png" alt="Get it on Paskoocheh" width=161 height=48 />
                     </picture>
                 </a>
-                <a href="https://www.apklis.cu/application/chat.delta" class="img-badge">
-                    <picture>
-                      <source srcset="../assets/badges/get-it-on-apklis.webp" type="image/webp">
-                      <source srcset="../assets/badges/get-it-on-apklis.png" type="image/png">
-                      <img src="../assets/badges/get-it-on-apklis.png" alt="Disponible en Apklis" width=139 height=48 />
-                    </picture>
-                </a>
                 <a href="https://www.amazon.com/dp/B0864PKVW3/" class="img-badge">
                     <picture>
                       <source srcset="../assets/badges/amazon-appstore.webp" type="image/webp">
@@ -55,11 +48,25 @@
                         <img src="../assets/badges/appgallery.png" alt="Explore it on AppGallery" width=159 height=48 />
                     </picture>
                 </a>
-                <a href="https://download.delta.chat/android/deltachat-gplay-release-{{VERSION_ANDROID}}.apk"><small>Download</small> APK</a>
             </div>
             <div class="descr">
                 <a href="https://github.com/deltachat/deltachat-android">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
             </div>
+            <details>
+                <summary>
+                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                </summary>
+                <div class="buttons">
+                    <a href="https://www.apklis.cu/application/chat.delta" class="img-badge">
+                        <picture>
+                          <source srcset="../assets/badges/get-it-on-apklis.webp" type="image/webp">
+                          <source srcset="../assets/badges/get-it-on-apklis.png" type="image/png">
+                          <img src="../assets/badges/get-it-on-apklis.png" alt="Disponible en Apklis" width=139 height=48 />
+                        </picture>
+                    </a>
+                    <a href="https://download.delta.chat/android/deltachat-gplay-release-{{VERSION_ANDROID}}.apk"><small>Download</small> APK</a>
+                </div>
+            </details>
         </div>
         <div class="box" id="ios">
             <div class="title">iPhone/iPad</div>
@@ -82,7 +89,6 @@
                 <a href="https://apps.apple.com/us/app/delta-chat-desktop/id1462750497" class="img-badge">
                     <img src="../assets/badges/mac-appstore.svg" alt="{%if tx.download.dl_mac_appstore != ""%}{{ tx.download.dl_mac_appstore }}{%else%}{{ txEn.download.dl_mac_appstore }}{%endif%}" width=187 height=48 />
                 </a>
-                <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.dmg"><small>Download</small> DeltaChat.dmg</a>
                 <a href="https://formulae.brew.sh/cask/deltachat"><small>Install with</small>Homebrew</a>
             </div>
             <div class="descr">
@@ -90,6 +96,14 @@
                 <br />
                 Homebrew manual install: <code>brew install --cask deltachat</code>
             </div>
+            <details>
+                <summary>
+                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                </summary>
+                <div class="buttons">
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.dmg"><small>Download</small> DeltaChat.dmg</a>
+                </div>
+            </details>
         </div>
         <div class="box" id="windows">
             <div class="title">Windows</div>
@@ -97,15 +111,23 @@
                 <a href="https://www.microsoft.com/en-us/p/deltachat/9pjtxx7hn3pk?activetab=pivot:overviewtab" class="img-badge">
                     <img src="../assets/badges/microsoft.svg" alt="{%if tx.download.dl_microsoft != ""%}{{ tx.download.dl_microsoft }}{%else%}{{ txEn.download.dl_microsoft }}{%endif%}" width=133 height=48 />
                 </a>
-                <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat%20Setup%20{{VERSION_DESKTOP}}.exe"><small>Download</small> Setup.exe</a>
             </div>
             <div class="descr">
                 <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
-                &ndash;
-                <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat%20{{VERSION_DESKTOP}}.exe">Get portable version (experimental)</a>
                 <br />
                 Winget install: <code>winget install 9PJTXX7HN3PK</code>
             </div>
+            <details>
+                <summary>
+                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                </summary>
+                <div class="buttons">
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat%20Setup%20{{VERSION_DESKTOP}}.exe"><small>Download</small> Setup.exe</a>
+                </div>
+                <div class="descr">
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat%20{{VERSION_DESKTOP}}.exe">Get portable version (experimental)</a>
+                </div>
+            </details>
         </div>
         <div class="box" id="linux">
             <div class="title">GNU/Linux</div>
@@ -117,10 +139,6 @@
                         <img src="../assets/badges/flathub.png" alt="{%if tx.download.flathub != ""%}{{ tx.download.flathub }}{%else%}{{ txEn.download.flathub }}{%endif%}" width=161 height=48 />
                     </picture>
                 </a>
-                <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop_{{VERSION_DESKTOP}}_amd64.deb"><small>Get .deb for</small> Debian/Ubuntu</a>
-                <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.x86_64.rpm"><small>Get .rpm for</small> Fedora</a>
-                <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.AppImage"><small>Get Universal</small> AppImage</a>
-                <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.tar.gz"><small>Get Universal</small> tar.gz</a>
                 <a href="https://aur.archlinux.org/packages/deltachat-desktop-git/"><small>Build from</small>AUR</a>
             </div>
             <div class="descr">
@@ -131,6 +149,17 @@
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code>
             </div>
+            <details>
+                <summary>
+                    <b>{%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}</b>
+                </summary>
+                <div class="buttons">
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop_{{VERSION_DESKTOP}}_amd64.deb"><small>Get .deb for</small> Debian/Ubuntu</a>
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.x86_64.rpm"><small>Get .rpm for</small> Fedora</a>
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.AppImage"><small>Get Universal</small> AppImage</a>
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.tar.gz"><small>Get Universal</small> tar.gz</a>
+                </div>
+            </details>
         </div>
         <div class="box" id="ubuntutouch">
             <div class="title">Ubuntu Touch</div>

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -49,9 +49,6 @@
                     </picture>
                 </a>
             </div>
-            <div class="descr">
-                <a href="https://github.com/deltachat/deltachat-android">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
-            </div>
             <details>
                 <summary class="noupgrades">
                     {%if tx.download.no_upgrades != ""%}{{ tx.download.no_upgrades }}{%else%}{{ txEn.download.no_upgrades }}{%endif%}
@@ -67,6 +64,9 @@
                     <a href="https://download.delta.chat/android/deltachat-gplay-release-{{VERSION_ANDROID}}.apk"><small>Download</small> APK</a>
                 </div>
             </details>
+            <div class="descr">
+                <a href="https://github.com/deltachat/deltachat-android">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
+            </div>
         </div>
         <div class="box" id="ios">
             <div class="title">iPhone/iPad</div>
@@ -92,8 +92,6 @@
                 <a href="https://formulae.brew.sh/cask/deltachat"><small>Install with</small>Homebrew</a>
             </div>
             <div class="descr">
-                <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
-                <br />
                 Homebrew manual install: <code>brew install --cask deltachat</code>
             </div>
             <details>
@@ -104,6 +102,9 @@
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.dmg"><small>Download</small> DeltaChat.dmg</a>
                 </div>
             </details>
+            <div class="descr">
+                <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
+            </div>
         </div>
         <div class="box" id="windows">
             <div class="title">Windows</div>
@@ -113,8 +114,6 @@
                 </a>
             </div>
             <div class="descr">
-                <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
-                <br />
                 Winget install: <code>winget install 9PJTXX7HN3PK</code>
             </div>
             <details>
@@ -128,6 +127,9 @@
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat%20{{VERSION_DESKTOP}}.exe">Get portable version (experimental)</a>
                 </div>
             </details>
+            <div class="descr">
+                <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
+            </div>
         </div>
         <div class="box" id="linux">
             <div class="title">GNU/Linux</div>
@@ -142,8 +144,6 @@
                 <a href="https://aur.archlinux.org/packages/deltachat-desktop-git/"><small>Build from</small>AUR</a>
             </div>
             <div class="descr">
-                <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
-                <br />
                 Flatpak manual install: <code>flatpak install flathub chat.delta.desktop</code><br />
                 Arch manual install: <code>yay -S deltachat-desktop-git</code><br />
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
@@ -160,6 +160,9 @@
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.tar.gz"><small>Get Universal</small> tar.gz</a>
                 </div>
             </details>
+            <div class="descr">
+                <a href="https://github.com/deltachat/deltachat-desktop">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
+            </div>
         </div>
         <div class="box" id="ubuntutouch">
             <div class="title">Ubuntu Touch</div>

--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -77,8 +77,7 @@ div.download-content {
 }
 
 summary.noupgrades {
-    color: #1e6bb8;
-    text-decoration: none;
+    font-weight: bold;
     cursor: pointer;
 }
 

--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -82,8 +82,8 @@ summary.noupgrades {
 }
 
 summary {
-  list-style-type: '➡ ';
+  list-style-type: '> ';
 }
 details[open] > summary {
-  list-style-type: '⬆ ';
+  list-style-type: '^ ';
 }

--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -75,3 +75,9 @@ div.download-content {
     font-weight: bold;
     cursor: pointer;
 }
+
+summary.noupgrades {
+    color: #1e6bb8;
+    text-decoration: none;
+    cursor: pointer;
+}

--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -81,3 +81,10 @@ summary.noupgrades {
     text-decoration: none;
     cursor: pointer;
 }
+
+summary {
+  list-style-type: '➡ ';
+}
+details[open] > summary {
+  list-style-type: '⬆ ';
+}

--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -77,13 +77,10 @@ div.download-content {
 }
 
 summary.noupgrades {
-    font-weight: bold;
+    color: #1e6bb8;
     cursor: pointer;
+    list-style: none;
 }
-
-summary {
-  list-style-type: '> ';
-}
-details[open] > summary {
-  list-style-type: '^ ';
+summary.noupgrades:hover {
+    text-decoration: underline;
 }


### PR DESCRIPTION
fix #823 

With these `<details>` tags I always wonder if people understand that they can click on it... maybe a sub-headline would be better in this case.

To give examples, I doubt a cuban user would find apklis now (which is maybe fine, as it's outdated there), and a ubuntu user who is overwhelmed by flatpak (friend of mine) would have a hard time finding .deb (but then again .deb failed for her because of an oudated ubuntu version).

I'm looking forward to an apt repository so much^^