### PR TITLE
chatmail.md is stable enough - make it translatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,13 @@ for more info see the comments in `./tools/t-dance.sh`.
 - create the source as `en/<name>.md`
 
 - modify `tools/.tx/config` - add a section for the new page
-  modify `tools/t-dance.sh` - add your page to `sfiles` variable
 
-- run `./tools/t-dance push--do-this-only-from-master`
+- modify `tools/t-dance.sh` - add your page to `sfiles` variable
+
+- after merging, from master, run `./tools/t-dance push--do-this-only-from-master`
+
+- after that, you may want to give the file a meaningful name on Transifex
+
 
 ### Update _typos_ in sources
 

--- a/tools/.tx/config
+++ b/tools/.tx/config
@@ -19,6 +19,12 @@ source_file = translations/delta-chat-pages.community-standardspo/en.po
 source_lang = en
 type        = PO
 
+[o:delta-chat:p:delta-chat-pages:r:chatmailpo]
+file_filter = translations/delta-chat-pages.chatmailpo/<lang>.po
+source_file = translations/delta-chat-pages.chatmailpo/en.po
+source_lang = en
+type        = PO
+
 [o:delta-chat:p:delta-chat-pages:r:contributepo]
 file_filter = translations/delta-chat-pages.contributepo/<lang>.po
 source_file = translations/delta-chat-pages.contributepo/en.po

--- a/tools/t-dance.sh
+++ b/tools/t-dance.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-sfiles=(blog contribute community-standards donate download help imprint index references user-voices verify-downloads serverguide)
+sfiles=(blog contribute chatmail community-standards donate download help imprint index references user-voices verify-downloads serverguide)
 tlangs=(ca cs de es fr gl id it nl pl pt pt_BR ru sk sq tr uk zh_CN)  # do not add `en` to this list
 
 


### PR DESCRIPTION
this PR follows the instructions in the README.md to make a page (here: the new en/chatmail.md) translatable, also adapting README

once merged, we need to run `./tools/t-dance push--do-this-only-from-master` on master and pull translations afterwards

closes #858