### PR TITLE
cleanup links

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -6,32 +6,30 @@ downloads: true
 
 ![An iOS user scanning a QR code on someone else's phone.](../assets/blog/2023-11-qr-scan.jpg)
 
-## Changelogs {#changelogs}
-
-* [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md)
-* [Android](https://deltachat.github.io/deltachat-android/CHANGELOG#delta-chat-android-changelog)
-* [iOS](https://deltachat.github.io/deltachat-ios/CHANGELOG#delta-chat-ios-changelog)
-* [Core](https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md)
-
-The desktop versions do not require Delta Chat to be installed on a phone.
-
 Minimal requirements:
 Android 4.1 Jelly Bean
 or iOS 12, iPhone 5s or iPad 5/Air/Mini 2
 or Windows 10, macOS 10.15 Catalina, Ubuntu 18.04, Fedora 29 or Debian 10
 or compatible systems.
 
-## Links
+The desktop versions do not require Delta Chat to be installed on a phone.
 
-* [Provider Database](https://providers.delta.chat/): Does my Provider work with Delta Chat?
-* [FAQ multiclient](help#multiclient): How to synchronize Desktop with another Delta Chat app.
-* [Verify Downloads](verify-downloads): Verify data integrity of downloads
-* [Desktop Installation Troubleshooting](https://github.com/deltachat/deltachat-desktop/blob/master/docs/TROUBLESHOOTING.md): Solutions for common desktop installation problems
 
-## Preview Builds
+## Changelogs & More {#changelogs}
 
-* [Desktop Previews]({% include desktop-previews-url %}): Pending changes for the desktop clients
-* [Android Nightly](https://download.delta.chat/android/nightly/): Built last night with the most recent core
-* [iOS Testflight](https://testflight.apple.com/join/uEMc1NxS): May contain not yet officially released iOS versions
+- Changelogs: [Desktop](https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md),
+  [Android](https://deltachat.github.io/deltachat-android/CHANGELOG#delta-chat-android-changelog),
+  [iOS](https://deltachat.github.io/deltachat-ios/CHANGELOG#delta-chat-ios-changelog),
+  [Core](https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md)
 
-Preview builds may come with new bugs and should not be used productive.
+- [Alternative Clients](https://support.delta.chat/t/list-of-all-know-client-projects/3059)
+
+- [Provider Database](https://providers.delta.chat/)
+
+- [Verify Downloads](verify-downloads)
+
+- [Desktop Installation Troubleshooting](https://github.com/deltachat/deltachat-desktop/blob/master/docs/TROUBLESHOOTING.md)
+
+- Preview Builds: [Desktop]({% include desktop-previews-url %}),
+  [Android Nightlies](https://download.delta.chat/android/nightly/),
+  [iOS Testflight](https://testflight.apple.com/join/uEMc1NxS)


### PR DESCRIPTION
- move all links to a single section

- move 'system requirements' up (would be best to have them in the respective sections, but this is already an improvement)

- 'FAQ multiclient' - this is probably not one of the first questions, so it seems okay to have that only in the normal FAQ; also, this comes from a time where our multiclient story was much worse, meanwhile, this is guided in the app as well

- add link to the new 'Alternative Clients' overview (which may be moved from forum to delta.chat)