### PR TITLE
FAQ: invite links make everything easier now

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -402,16 +402,17 @@ you can generate an invite link.
 If you are together in person,
 you can show a QR code to your chat partner.
 
-1. For **Group invitations**,
-   tap the chat group title to see its member list,
-   and select "QR Invite code".
-2. For **direct 1:1 chat invitations**,
-   tap the QR Code icon <img style="vertical-align:middle; width:1.8em; margin:1px" src="../assets/help/qr-icon.png" />
-   on the Delta Chat app main screen.
+- For **Group invitations**,
+  tap the chat group title to see its member list,
+  and select "QR Invite code".
+
+- For **direct 1:1 chat invitations**,
+  tap the QR Code icon <img style="vertical-align:middle; width:1.8em; margin:1px" src="../assets/help/qr-icon.png" />
+  on the Delta Chat app main screen.
 
 Let your chat partner scan the QR image
 with their Delta Chat app,
-or click "Copy" to create an invite link
+or click "Copy" or "Share" to create an invite link
 and share it with your chat partner.
 
 Now wait while [Secure-Join network messages are exchanged](https://securejoin.delta.chat/en/latest/new.html#setup-contact-protocol) between both devices.

--- a/en/help.md
+++ b/en/help.md
@@ -395,40 +395,26 @@ End-to-end encryption is guaranteed if there is a green checkmark next to the ch
 
 ### How can I get guaranteed end-to-end encryption and green checkmarks? {#howtoe2ee}
 
-Meet your chat partner outside Delta Chat, preferably in person
-but a second channel like a video chat
-or a different messenger is fine as well.
-Perform the following QR show/scan procedure with your chat partner.
-One of you is the "Inviter", the other is the "Joiner". 
+If you have a second communication channel with your chat partner,
+like a video chat or a different messenger,
+you can generate an invite link.
 
-**Inviter side**:
+If you are together in person,
+you can show a QR code to your chat partner.
 
-- Group invitation: 
-  Tap the chat group title to see its member list, and select "QR Invite code". 
-  Share the QR image with the other side either in person or through a second channel.
+1. For **Group invitations**,
+   tap the chat group title to see its member list,
+   and select "QR Invite code".
+2. For **direct 1:1 chat invitations**,
+   tap the QR Code icon <img style="vertical-align:middle; width:1.8em; margin:1px" src="../assets/help/qr-icon.png" />
+   on the Delta Chat app main screen.
 
-- Direct 1:1 chat invitation: 
-  Tap the QR Code icon <img style="vertical-align:middle; width:1.8em; margin:1px" src="../assets/help/qr-icon.png" />
-  on the Delta Chat app main screen.
-  Share the QR image with the other side either in person or through a second channel.
+Let your chat partner scan the QR image
+with their Delta Chat app,
+or click "Copy" to create an invite link
+and share it with your chat partner.
 
-**Joiner side**:
-
-- Tap the QR Code icon <img style="vertical-align:middle; width:1.8em; margin:1px" src="../assets/help/qr-icon.png" />
-  on the Delta Chat app main screen.
-
-- Choose "SCAN QR CODE" and scan the QR Code 
-  that you see from your chat partner in a second channel.
-
-- Tap "OK"
-
-If the QR code scanning doesn't work in your situation,
-you can also **Share** (or **Copy to Clipboard**) an equivalent invite link
-to the other person through a second channel.
-
-**Both Inviter and Joiner**:
-
-Wait while [Secure-Join network messages are exchanged](https://securejoin.delta.chat/en/latest/new.html#setup-contact-protocol) between both devices.
+Now wait while [Secure-Join network messages are exchanged](https://securejoin.delta.chat/en/latest/new.html#setup-contact-protocol) between both devices.
 
 - If both devices are online,
   both sides will eventually see a (group or direct) chat with a green checkmark


### PR DESCRIPTION
fix #862 

Now that we have invite links, the QR code flow is less important. It's mostly useful for chat partners who just met and don't have a second channel yet.

We also don't really need the "joiner side" anymore. If they are together in person, they already know where the QR code menu is. If it's a link, they do not even need the QR menu.

Unfortunately the invite QR codes are still `OPENPGP4FPR` codes, so if the joiner doesn't have Delta Chat installed, scanning them with any app will not lead to https://i.delta.chat. This is the only thing which makes me hesitate whether we can already delete the whole "Joiner Side" paragraph. But as long as they have Delta Chat installed at all, even a normal scanner app _should_ open the app. The FAQ still implies that the joiner needs to have Delta Chat installed.