### PR TITLE
FAQ: only talk about accounts when it's about interacting with e-mail

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -495,7 +495,7 @@ even if the contact is a member there.
 **Your contact is using Delta Chat on a second device (phone or laptop)**
 
 If they have another device with a Delta Chat app running,
-they should remove the account from the new device
+they should remove the profile from the new device
 and add it [as a second device as described here](#multiclient).
 As soon as they message you afterwards, the warning will be gone
 and guaranteed encryption is established with both devices of your contact. 
@@ -503,8 +503,8 @@ and guaranteed encryption is established with both devices of your contact.
 **Your contact reinstalled Delta Chat using their old account login**
  
 If they have [a backup file](#backup), 
-they should remove the account from the new device 
-and rather import the backup file to re-create their account. 
+they should remove the profile from the new device
+and rather import the backup file to re-create their profile.
 As soon as they message you afterwards, the warning will be gone
 and guaranteed encryption is re-established for this contact.
 
@@ -654,12 +654,12 @@ deliver messages to recipient's devices.
 
 Both for protecting against metadata-collecting e-mail servers 
 as well as against the threat of device seizure
-we recommend to use a Delta Chat optimized [e-mail server instance](https://delta.chat/serverguide)
-to create pseudonymous temporary accounts through QR-code scans.
-Note that Delta Chat apps on all platforms support multiple accounts 
-so you can easily use action-specific "1-week" or "1-month" accounts next to your "main" account
-with the knowledge that all temporary account data, along with all metadata, will be deleted.
-Moreover, if a device is seized then contacts using temporary e-mail accounts
+we recommend to use a [chatmail server](chatmail)
+to create pseudonymous temporary profiles through QR-code scans.
+Note that Delta Chat apps on all platforms support multiple profiles
+so you can easily use situation-specific profiles next to your "main" profile
+with the knowledge that all their data, along with all metadata, will be deleted.
+Moreover, if a device is seized then contacts using temporary profiles
 can not be identified easily, as compared to messengers which reveal
 phone numbers in chat groups which in turn are often associated with legal identities.
 
@@ -697,7 +697,7 @@ and their non-Autocrypt e-mail app.
 ### How can i get an end-to-end encrypted chat with a Delta Chat contact who sometimes uses webmail or another non-Autocrypt e-mail app? 
 
 If you need a safely end-to-end encrypted chat with a contact 
-who is using their account both with Delta Chat and non-Autocrypt apps (e.g. webmail),
+who is using their e-mail account both with Delta Chat and non-Autocrypt apps (e.g. webmail),
 it's best to setup [guaranteed end-to-end encryption with them](#howtoe2ee)
 and then create a guaranteed end-to-end encrypted group chat with you two as members. 
 In this group chat all messages will be end-to-end encrypted 
@@ -841,7 +841,7 @@ independent security analysis, from most recent to older:
 
 ### Can I use Delta Chat on multiple devices at the same time?
 
-Yes. Delta Chat 1.36 comes with a new, experimental function for using the same account on different devices:
+Yes. Delta Chat 1.36 comes with a new, experimental function for using the same profile on different devices:
 
 - Make sure both devices are on the same Wi-Fi or network
 
@@ -882,7 +882,7 @@ One device is not needed for the other to work.
   (we try hard to make the app work in background, but [systems tend to kill apps](https://dontkillmyapp.com), unfortunately)
 
 - Delta Chat is **already logged in** on the destination device?
-  You can use multiple accounts per device, just [add another account](#multiple-accounts)
+  You can use multiple profiles per device, just [add another profile](#multiple-accounts)
 
 - If you still have problems or if you **cannot scan a QR code**
   try the **manual transfer** described below
@@ -896,8 +896,8 @@ This method is only recommended if "Add Second Device" as described above does n
   screen unlock PIN, pattern, or password. Then you can click on "Start
   Backup". This saves the backup file to your device. Now you have to transfer
   it to the other device somehow.
-- On the new device, on the login screen, instead of logging into your email
-  account, choose "Import Backup". After import, your conversations, encryption
+- On the new device, in the "I already have a profile" menu,
+  choose "restore from backup". After import, your conversations, encryption
   keys, and media should be copied to the new device.
   - **If you use iOS:** and you encounter difficulties, maybe
     [this guide](https://support.delta.chat/t/import-backup-to-ios/1628) will
@@ -1048,10 +1048,10 @@ Enabling "Only Fetch from DeltaChat folder" makes sense if you have **both**:
 In this case, Delta Chat doesn't need to watch the Inbox, and it's enough to only watch the DeltaChat folder.
 
 
-### How can I change my account to a different e-mail address?
+### How can I use a different e-mail address with my profile?
 
 1. Change your address in “Settings → Advanced → Password and Account” and
-   enter the password of your new account (and if necessary, server settings).
+   enter the password of your new e-mail account (and if necessary, server settings).
    You will get an information notice about the fact that you are moving to a new address. 
    An additional notice will also show up in your "Device messages" chat. 
 
@@ -1272,7 +1272,7 @@ Concretely, Delta Chat developments have so far been funded from these sources:
   completing Rust/Python bindings and instigating a Chat-bot eco-system. 
 
 - In 2021 we received further EU funding for two Next-Generation-Internet
-  proposals, namely for [EPPD - e-mail provider portability directory](https://dapsi.ngi.eu/hall-of-fame/eppd/) (~97K EUR) and [AEAP - email address porting](https://nlnet.nl/project/EmailPorting/) (~90K EUR) which resulted in better multi-account support, improved QR-code contact and group setups and many networking improvements on all platforms.
+  proposals, namely for [EPPD - e-mail provider portability directory](https://dapsi.ngi.eu/hall-of-fame/eppd/) (~97K EUR) and [AEAP - email address porting](https://nlnet.nl/project/EmailPorting/) (~90K EUR) which resulted in better multi-profile support, improved QR-code contact and group setups and many networking improvements on all platforms.
 
 - From End 2021 till March 2023 we received *Internet Freedom* funding (500K USD) from the
   U.S. Bureau of Democracy, Human Rights and Labor (DRL). 

--- a/en/help.md
+++ b/en/help.md
@@ -654,7 +654,7 @@ deliver messages to recipient's devices.
 
 Both for protecting against metadata-collecting e-mail servers 
 as well as against the threat of device seizure
-we recommend to use a [chatmail server](chatmail)
+we recommend to use a [chatmail server](https://delta.chat/chatmail)
 to create pseudonymous temporary profiles through QR-code scans.
 Note that Delta Chat apps on all platforms support multiple profiles
 so you can easily use situation-specific profiles next to your "main" profile


### PR DESCRIPTION
fix #887 

I looked through our FAQ where we still need the "account" wording and where we can replace it with "profile".

In all cases where it's about how the e-mail account interacts with the wider e-mail ecosystem, e.g. because of using the same account with non-Autocrypt clients, deleting the e-mail account, e-mail accounts of chat partners which might not use Delta Chat, deletion on the server, etc. I kept using the `e-mail account` wording.

In the below cases I found that the `profile` wording even improves the FAQ: