### PR TITLE
download: we have an official arch package now

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -141,10 +141,10 @@
                         <img src="../assets/badges/flathub.png" alt="{%if tx.download.flathub != ""%}{{ tx.download.flathub }}{%else%}{{ txEn.download.flathub }}{%endif%}" width=161 height=48 />
                     </picture>
                 </a>
-                <a href="https://archlinux.org/packages/extra/any/deltachat-desktop/"><small>Install package for</small>arch linux</a>
             </div>
             <div class="descr">
                 Flatpak manual install: <code>flatpak install flathub chat.delta.desktop</code><br />
+                Arch manual install: <code>pacman -S deltachat-desktop</code><br />
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code>
             </div>

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -141,11 +141,10 @@
                         <img src="../assets/badges/flathub.png" alt="{%if tx.download.flathub != ""%}{{ tx.download.flathub }}{%else%}{{ txEn.download.flathub }}{%endif%}" width=161 height=48 />
                     </picture>
                 </a>
-                <a href="https://aur.archlinux.org/packages/deltachat-desktop-git/"><small>Build from</small>AUR</a>
+                <a href="https://archlinux.org/packages/extra/any/deltachat-desktop/"><small>Install package for</small>arch linux</a>
             </div>
             <div class="descr">
                 Flatpak manual install: <code>flatpak install flathub chat.delta.desktop</code><br />
-                Arch manual install: <code>yay -S deltachat-desktop-git</code><br />
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code>
             </div>


### PR DESCRIPTION
closes #908

@Jikstra or is there still a reason to keep the AUR package there if there is an official package now? I don't use arch, no idea.