### PR TITLE
fix download labels on linux downloads

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -157,11 +157,13 @@
                 <div class="buttons">
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop_{{VERSION_DESKTOP}}_amd64.deb"><small>Get .deb for x86_64</small> Debian/Ubuntu</a>
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.x86_64.rpm"><small>Get .rpm for x86_64</small> Fedora</a>
-                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.AppImage"><small>Get Universal</small> AppImage</a>
-                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.tar.gz"><small>Get Universal</small> tar.gz</a>
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}.AppImage"><small>Get x86_64</small> AppImage</a>
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.tar.gz"><small>Get x86_64</small> tar.gz</a>
+                    <br />
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop_{{VERSION_DESKTOP}}_arm64.deb"><small>Get .deb for arm64</small> Debian/Ubuntu</a>
-                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.aarch64.rpm"><small>Get .rpm for aarch64</small> Fedora</a>
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}.aarch64.rpm"><small>Get .rpm for arm64</small> Fedora</a>
                     <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/DeltaChat-{{VERSION_DESKTOP}}-arm64.AppImage"><small>Get arm64</small> AppImage</a>
+                    <a href="https://download.delta.chat/desktop/v{{VERSION_DESKTOP}}/deltachat-desktop-{{VERSION_DESKTOP}}-arm64.tar.gz.tar.gz"><small>Get arm64</small> tar.gz</a>
                 </div>
             </details>
             <div class="descr">


### PR DESCRIPTION
universal meant for all linux distributions before, with the addition of the universal architectures on macOS the meaning has changed to mean "works on both arm64 and intel/x86_84" which is not correct for the linux builds.