### PR TITLE
make 'system requirements' less language dependent

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -85,7 +85,7 @@
             </div>
             <div>
                 {%if tx.download.minimum != ""%}{{ tx.download.minimum }}{%else%}{{ txEn.download.minimum }}{%endif%}:
-                iOS 12, iPhone 5s or iPad 5/Air/Mini 2
+                iOS 12, iPhone 5s, iPad 5/Air/Mini 2
             </div>
             <div class="descr">
                 <a href="https://github.com/deltachat/deltachat-ios">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
@@ -167,7 +167,7 @@
             </div>
             <div>
                 {%if tx.download.minimum != ""%}{{ tx.download.minimum }}{%else%}{{ txEn.download.minimum }}{%endif%}:
-                Ubuntu 18.04, Fedora 29, Debian 10 or compatible systems
+                Ubuntu 18.04, Fedora 29, Debian 10, Compatible Systems
             </div>
             <details>
                 <summary class="noupgrades">


### PR DESCRIPTION
avoid the english word 'or' in requirements and make them less language dependent (the OS names are usually not translated anyways and subject to change often, so it makes sense to have that part more independent)

successor of #923
