### PR TITLE
Fix broken links to docker/docker-compose installation (in the server guide)

### DIFF
--- a/ca/serverguide.md
+++ b/ca/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/cs/serverguide.md
+++ b/cs/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/en/serverguide.md
+++ b/en/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/es/serverguide.md
+++ b/es/serverguide.md
@@ -23,7 +23,7 @@ Qué necesitas:
 ## Instalando Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### Si docker.com está Bloqueado:
 

--- a/fr/serverguide.md
+++ b/fr/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/gl/serverguide.md
+++ b/gl/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/id/serverguide.md
+++ b/id/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/pt/serverguide.md
+++ b/pt/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/pt_BR/serverguide.md
+++ b/pt_BR/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/sk/serverguide.md
+++ b/sk/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/tr/serverguide.md
+++ b/tr/serverguide.md
@@ -26,7 +26,7 @@ What you need:
 ## Installing Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### If docker.com is Blocked:
 

--- a/zh_CN/serverguide.md
+++ b/zh_CN/serverguide.md
@@ -23,7 +23,7 @@ with Delta Chat. It is also included in this guide.
 ## 安装 Docker
 
 As a prerequisite you need to install [docker and
-docker-compose](https://docs.mailcow.email/i_u_m/i_u_m_install/).
+docker-compose](https://docs.mailcow.email/getstarted/install/#docker-and-docker-compose-installation).
 
 ### 如果 docker.com 被屏蔽：
 


### PR DESCRIPTION
Links to installing `docker` and `docker-compose` are broken and yield a 404 (also in german for some reason)

![image](https://github.com/user-attachments/assets/be552d27-be4b-4317-9a36-9461873e4969)
