### PR TITLE
recent android update will require android5

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -44,7 +44,7 @@
             </div>
             <div class="descr">
                 {%if tx.download.minimum != ""%}{{ tx.download.minimum }}{%else%}{{ txEn.download.minimum }}{%endif%}:
-                Android 4.1 Jelly Bean
+                Android 5.0 Lollipop
             </div>
             <details>
                 <summary class="noupgrades">


### PR DESCRIPTION
the bump was needed to target api34,
androidx dropped support for android4.
this happened already before for other libs - and for the ndk (!) -,
and we always found workarounds sooner or later,
but this time, _many_ workarounds would be needed, this is no longer reasonable.

5 years ago, we were already considering to do that step, that time affecting 5% of users ... https://github.com/deltachat/deltachat-android/pull/1115

so, one can say we gave these users 5 more years a chance, and 90% of them meanwhile got a new device or did an update.