### PR TITLE
Collect most recent iOS releases in a document

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,16 @@
+# Delta Chat Releases
+
+## iOS
+
+| Release                  | Core Version                   | Remarks            |
+| ------------------------ | ------------------------------ |--------------------|
+| [`1.46.10`][ios-1.46.10] | [`1.142.12`][core-1.142.12]    |                    |
+| [`1.46.9`][ios-1.46.9]   | [`1.142.2`][core-1.142.2]      |                    |
+| [`1.46.8`][ios-1.46.8]   | [`1.142.2`][core-1.142.2]      | Testflight only    |
+
+[ios-1.46.10]: https://github.com/deltachat/deltachat-ios/releases/tag/1.46.10
+[ios-1.46.9]: https://github.com/deltachat/deltachat-ios/releases/tag/1.46.9
+[ios-1.46.8]: https://github.com/deltachat/deltachat-ios/releases/tag/1.46.8
+
+[core-1.142.12]: https://github.com/deltachat/deltachat-core-rust/releases/tag/v1.142.12
+[core-1.142.2]: https://github.com/deltachat/deltachat-core-rust/releases/tag/v1.142.2


### PR DESCRIPTION
- Idea war to start _somewhere_. This document gives a simple overview which app-release uses which Core-version.
- I opted for a table in this case as it made sense to me, but I'm also happy to convert it into a list with some headlines in between. Just HMI!
- Feel free to add your releases on other platforms :-)