### PR TITLE
show download options in help & offline help

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -1230,7 +1230,7 @@ Delta Chat is available for all major and some minor platforms:
 
 - If unavailable, use the **mirror** at <https://deltachat.github.io/deltachat-pages>
 
-- Open one of the following **app store and search for "Delta Chat":**
+- Open one of the following **app stores and search for "Delta Chat":**
   Google Play Store, F-Droid, Huawei App Gallery, Amazon App Store, iOS and macOS App Store, Microsoft Store
 
 - Check the **package manager** of your Linux distributions

--- a/en/help.md
+++ b/en/help.md
@@ -1221,6 +1221,23 @@ Otherwise you might receive undecryptable messages from those group chats.
 - See [Standards used in Delta Chat]({% include standards-url %}).
 
 
+
+### Where can my friends find Delta Chat?
+
+Delta Chat is available for all major platforms:
+
+- The **official website**, <https://delta.chat/download> shows all options in detail
+
+- If unavailable, use the **mirror** at <https://deltachat.github.io/deltachat-pages>
+
+- Open one of the following **app store and search for "Delta Chat":**
+  Google Play Store, F-Droid, Huawei App Gallery, Amazon App Store, iOS and macOS App Store, Microsoft Store
+
+- Check the **package manager** of your Linux distributions
+
+- **Android APKs** are also available on <https://github.com/deltachat/deltachat-android/releases>
+
+
 ### How are Delta Chat developments funded? 
 
 Delta Chat does not receive any Venture Capital and

--- a/en/help.md
+++ b/en/help.md
@@ -1224,7 +1224,7 @@ Otherwise you might receive undecryptable messages from those group chats.
 
 ### Where can my friends find Delta Chat?
 
-Delta Chat is available for all major platforms:
+Delta Chat is available for all major and some minor platforms:
 
 - The **official website**, <https://delta.chat/download> shows all options in detail
 


### PR DESCRIPTION
this is mainly useful when browsing the help offline, when maybe having never opened the official homepage before. or, in case that gets offline,
show some alternatives, before or after the fact.