### PR TITLE
fix link to microsoft store

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -111,7 +111,7 @@
         <div class="box" id="windows">
             <div class="title">Windows</div>
             <div class="buttons">
-                <a href="https://www.microsoft.com/en-us/p/deltachat/9pjtxx7hn3pk?activetab=pivot:overviewtab" class="img-badge">
+                <a href="https://apps.microsoft.com/detail/9pjtxx7hn3pk" class="img-badge">
                     <img src="../assets/badges/microsoft.svg" alt="{%if tx.download.dl_microsoft != ""%}{{ tx.download.dl_microsoft }}{%else%}{{ txEn.download.dl_microsoft }}{%endif%}" width=133 height=48 />
                 </a>
             </div>


### PR DESCRIPTION
the old link returns a 503 since some days,
the new one seems to be better also as no language and selected tab is included.