### PR TITLE
refine troubleshooting for iOS/macOS multidevice

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -849,6 +849,10 @@ One device is not needed for the other to work.
   and make sure, **Private Network** is selected as "Network profile type"
   (after transfer, you can change back to the original value)
 
+- On **iOS**, make sure **System Settings → Delta Chat → Local Network** access is granted
+
+- On **macOS**, enable **System Settings → Privacy & Security → Local Network → Delta Chat**
+
 - Your system might have a "personal firewall",
   which is known to cause problems (especially on Windows).
   **Disable the personal firewall** for Delta Chat on both ends and try again

--- a/en/help.md
+++ b/en/help.md
@@ -849,9 +849,9 @@ One device is not needed for the other to work.
   and make sure, **Private Network** is selected as "Network profile type"
   (after transfer, you can change back to the original value)
 
-- On **iOS**, make sure **System Settings → Delta Chat → Local Network** access is granted
+- On **iOS**, make sure "System Settings / Delta Chat / **Local Network**" access is granted
 
-- On **macOS**, enable **System Settings → Privacy & Security → Local Network → Delta Chat**
+- On **macOS**, enable "System Settings / Privacy & Security / **Local Network** / Delta Chat"
 
 - Your system might have a "personal firewall",
   which is known to cause problems (especially on Windows).


### PR DESCRIPTION
these information are esp. useful
if the user did not confirm before
or the confirmation dialog did not pop up for whatever reason.

i am not sure if the click paths exist in this way also on older ios/macos, but that seems okay, we cannot maintain an exhaustive list here, these are more best-effort hints

closes #998