### PR TITLE
fix misaligned video on larger screens

### DIFF
--- a/_posts/2024-11-20-webxdc-realtime.md
+++ b/_posts/2024-11-20-webxdc-realtime.md
@@ -114,7 +114,7 @@ because it requires a running chat bot on some unix-ish server.
 
 ## Live Chat: realtime chat in a chat :)
 
-<video controls style="width:150px; max-width: 50%;float:right;margin-left:5px;" autoplay muted loop playsinline><source src="../assets/blog/2024-11-livechat2.mp4" type="video/mp4"></video>
+<video controls style="width:150px; max-width: 50%;float:right;margin-left:5px;clear:both;margin-top:1em;" autoplay muted loop playsinline><source src="../assets/blog/2024-11-livechat2.mp4" type="video/mp4"></video>
 The [LiveChat app](https://github.com/deltazen/live-chat) 
 provides ephemeral chatting with realtime typing-indicators
 between anyone in a chat group who starts the live chat. 


### PR DESCRIPTION
i think, the videos are meant to be all on the right side, not like that (otherwise, please close :)

<img width="903" alt="Screenshot 2024-11-20 at 12 01 33" src="https://github.com/user-attachments/assets/db8c75e1-088f-4400-86b6-8408706b2514">

