### PR TITLE
use 'result' instead of '_site' as site folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ _site/
 .*.swp
 *.po
 
-# ignore private scripts and directories, eg. jekyll-build-local.prv.sh
-*.prv*
-
 # ignore tools/tranlations, we copy the files to the corresponding language directories
 tools/translations/
 

--- a/tools/create-local-help.py
+++ b/tools/create-local-help.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
 
     if len(sys.argv) < 3:
         raise SystemExit("usage: create-local-help.py INPUT_DIR OUTPUT_DIR [--add-top-links]"
-                      +"\n   eg. create-local-help.py _site     ../foobar")
+                      +"\n   eg. create-local-help.py result    ../foobar")
 
     srcdir = sys.argv[1]
     print("using source directory:        " + srcdir)

--- a/tools/t-dance.sh
+++ b/tools/t-dance.sh
@@ -89,13 +89,11 @@ create_markdown_files() {
 
 
 create_html_files() {
-	# if you want to rebuild the html files when markdown is updated,
-	# create the file `tools/create-html.prv.sh` with eg. the following content:
-	# `cd ..; jekyll build --destination <html-folder>; echo "Options +MultiViews" > <html-folder>/.htaccess; cd tools`  
-	if [ -f ./create-html.prv.sh ]; then
-		echo "Creating html-files from the markdown files ..."
-		./create-html.prv.sh
-	fi
+  # create html files from markdown
+  cd ..
+  bundle exec jekyll build
+  mv _site result
+  cd tools
 }
 
 


### PR DESCRIPTION
use 'result' instead of '_site' as site folder; this unifies nix and t-dance output