### PR TITLE
mention the 2024 audit

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -543,7 +543,7 @@ and GnuPG (GPG), a command line tool implementing OpenPGP.
 Many public critiques of OpenPGP actually discuss GnuPG which Delta Chat has never used. 
 Delta Chat rather uses the OpenPGP Rust implementation [rPGP](https://github.com/rpgp/rpgp),
 available as [an independent "pgp" package](https://crates.io/crates/pgp),
-and [security-audited in 2019](https://delta.chat/assets/blog/2019-first-security-review.pdf). 
+and [security-audited in 2019 and 2024](#security-audits). 
 
 We aim, along with other OpenPGP implementors, 
 to further improve security characteristics by implementing the


### PR DESCRIPTION
the section "Is OpenPGP secure?" did mention the 2019 audit, but not the new 2024 one. this PR fixes that, and links to the [on-page audit-overview](https://staging.delta.chat/1050/en/help#security-audits)

(we could also link to https://github.com/rpgp/docs/tree/main/audits, however, as we do the effort to translate the audit-overview, for the casual reader, it seems better to point to that)

successor of https://github.com/deltachat/deltachat-pages/pull/1048