### PR TITLE
Remove outdated paragraph about registering with newsletters

### DIFF
--- a/_posts/2023-12-13-chatmail.md
+++ b/_posts/2023-12-13-chatmail.md
@@ -86,7 +86,24 @@ and by design hardly know any personally identifiable data.
 Chatmail services really act more as an *e-mail router* rather than an account platform. 
 Anyone can get a slot but only end-to-end encrypted messages can freely travel. 
 
-You can create as many addresses as you want.
+
+## Registering with newsletters or platforms, without privacy leaks
+
+<a href="https://brettscott.substack.com/p/tech-doesnt-make-our-lives-easier">
+<img src="../assets/blog/tech-not-easier.webp" width="210" style="float:right; margin-left:1em;" />  </a>
+
+**UPDATE:** Since April 2025,
+new chatmail relay server users
+can't receive unencrypted messages anymore.
+So this paragraph is outdated:
+
+~~Delta Chat apps supports using multiple addresses out of the box. 
+With [nine.testrun.org](https://nine.testrun.org) you can always setup
+additional addresses to receive newsletters or register with websites.
+Incoming messages are allowed to be un-encrypted
+(this might become user-configurable in the future)
+and so they are just fine for receiving e-mail messages.~~
+
 If you don't need or use an additional address anymore, 
 simply delete it on your device.
 We are happy to see you go and, who knows, 

--- a/_posts/2023-12-13-chatmail.md
+++ b/_posts/2023-12-13-chatmail.md
@@ -86,19 +86,7 @@ and by design hardly know any personally identifiable data.
 Chatmail services really act more as an *e-mail router* rather than an account platform. 
 Anyone can get a slot but only end-to-end encrypted messages can freely travel. 
 
-
-## Registering with newsletters or platforms, without privacy leaks
-
-<a href="https://brettscott.substack.com/p/tech-doesnt-make-our-lives-easier">
-<img src="../assets/blog/tech-not-easier.webp" width="210" style="float:right; margin-left:1em;" />  </a>
-
-Delta Chat apps supports using multiple addresses out of the box. 
-With [nine.testrun.org](https://nine.testrun.org) you can always setup
-additional addresses to receive newsletters or register with websites.
-Incoming messages are allowed to be un-encrypted
-(this might become user-configurable in the future)
-and so they are just fine for receiving e-mail messages. 
-
+You can create as many addresses as you want.
 If you don't need or use an additional address anymore, 
 simply delete it on your device.
 We are happy to see you go and, who knows, 


### PR DESCRIPTION
Since new chatmail relay addresses can't receive unencrypted messages anymore, this is outdated.