### PR TITLE
tarpit.fun is hosted in Germany

### DIFF
--- a/en/chatmail.md
+++ b/en/chatmail.md
@@ -26,7 +26,7 @@ securely interoperable with chatmail and classic e-mail servers.
 - [chika.aangat.lahat.computer](https://chika.aangat.lahat.computer/)
   operates in the US 
 
-- [tarpit.fun](https://tarpit.fun) is hosted in Austria 
+- [tarpit.fun](https://tarpit.fun) is hosted in Germany
 
 There are additional chatmail servers not listed publically.  
 


### PR DESCRIPTION
changed it on https://github.com/chatmail/pages already.