### PR TITLE
FAQ: Changing e-mail addresses is temporarily disabled

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -1062,6 +1062,11 @@ In this case, Delta Chat doesn't need to watch the Inbox, and it's enough to onl
 
 ### How can I use a different e-mail address with my profile?
 
+Note: 
+Changing email addresses is temporarily disabled
+because of ongoing changes to the DeltaChat core.
+It should be available again in a few months.
+
 1. Change your address in “Settings → Advanced → Password and Account” and
    enter the password of your new e-mail account (and if necessary, server settings).
    You will get an information notice about the fact that you are moving to a new address. 


### PR DESCRIPTION
https://github.com/chatmail/core/commit/4a2bfe03dab3c8a7f3297cb47719d0f3392c7201 disabled AEAP. To avoid the terrible disappointment / slight annoyance that comes with reading the FAQ, trying to change your address and it not actually working, I think there should be a note in the FAQ. Since the error message states that it should be back in a few months, I tried to mirror that.