### PR TITLE
hide header and footers, show-comments-button on printing

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -6,7 +6,7 @@
 <div id="comments-list" style="border-top: 1px solid #BBB;"></div>
 <noscript><p>You need JavaScript to view comments here.</p></noscript>
 <p><a id="load-comment" class="comment-button">Show Comments</a></p>
-<p><br>You can reply on any Fediverse (Mastodon, Pleroma, etc.) website or app by pasting this URL into the search field of your client:<br>
+<p id="comments-hint"><br>You can reply on any Fediverse (Mastodon, Pleroma, etc.) website or app by pasting this URL into the search field of your client:<br>
 <pre><a href='https://{{ mastodon_instance }}/@{{ mastodon_user }}/{{ page.com_id }}' target='_blank'>https://{{ mastodon_instance }}/@{{ mastodon_user }}/{{ page.com_id }}</a></pre>
 <script src="../assets/js/purify.js"></script>
 <script>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -271,3 +271,10 @@ sup[role="doc-noteref"]:before {
 sup[role="doc-noteref"]:after {
     content: "]";
 }
+
+
+@media print {
+    #menu, #footer, #load-comment, #comments-hint, .deltachat-banner {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
this PR hides the header, the footer and the "show comments" button on printing,

the comments themselves are printed, if loaded  before