### PR TITLE
remove unmaintained community experiment

### DIFF
--- a/en/contribute.md
+++ b/en/contribute.md
@@ -40,12 +40,6 @@ For more background we recommend to read and follow our [blog](https://delta.cha
 The following Delta Chat related communication channels are run by third parties
 which may or may not follow our [Community Standards](community-standards): 
 
-- English-speaking Delta Chat community group, you can join the group:
-  * [In Delta Chat]({% include dc-community-url %})
-  * [In Matrix](https://matrix.to/#/#Delta.Chat:matrix.org)
-  * [In XMPP](xmpp:deltachat-en@chat.disroot.org?join)
-  * [In Telegram](https://t.me/deltachat_community)
-
 - A [Lemmy community](https://lemmy.zip/c/delta_chat)
   which you can follow by putting `!delta_chat@lemmy.zip` 
   into the search field of your fediverse app.


### PR DESCRIPTION
Delta Chat is for "family & friends", ppl one trusts.

the public community is currently somehow unmaintained, also getting here and there social issues by some ppl using outdating clients or doing harm on purpose. also, ppl are experimenting partly with weird setups and keys there.

apart from that, technically the experiment went nice so far, 150+ ppl could chat e2ee in a reliable way

