### PR TITLE
fix broken verification link

### DIFF
--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -20,9 +20,9 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
 
 ## Desktop
 
-The public key used for signing desktop releases is published below and on <https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu>.
-
 You can find detailed instructions for verification at `https://download.delta.chat/desktop/v<version>/signature.asc`
+
+The public key used for signing desktop releases is published below and on <https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu>.
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -22,7 +22,7 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
 
 The public key used for signing desktop releases is published below and on <https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu>.
 
-You can find detailed instructions for verification at `https://download.delta.chat/desktop/v<version>/signature.asc`.
+You can find detailed instructions for verification at `https://download.delta.chat/desktop/v<version>/signature.asc`
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -22,7 +22,7 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
 
 The public key used for signing desktop releases is published below and on <https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu>.
 
-You can find detailed instructions for verification at [`https://download.delta.chat/desktop/v<version>/signature.asc`](https://download.delta.chat/desktop/).
+You can find detailed instructions for verification at `https://download.delta.chat/desktop/v<version>/signature.asc`.
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -22,7 +22,7 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
 
 The public key used for signing desktop releases is published below and on <https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu>.
 
-You can find detailed instructions for verification at `https://download.delta.chat/desktop/<version>/signature.asc` (example: for v1.59.1 you can find instructions in <https://download.delta.chat/desktop/v1.59.1/signature.asc>).
+You can find detailed instructions for verification at [`https://download.delta.chat/desktop/v<version>/signature.asc`](https://download.delta.chat/desktop/).
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
the example is subject to be outdated, as already happening now, after a very short time.

just remove the link, ppl into that will manage to create the link themselves, this is the smallest issue.

came over that via https://support.delta.chat/t/broken-link-in-https-delta-chat-en-verify-downloads/4032