### PR TITLE
make clearer, that non-chatmail is supporting e2ee

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -433,8 +433,8 @@ If you use default [chatmail relays](https://chatmail.at/relays),
 it is impossible to receive or send messages without end-to-end encryption. 
 
 If you instead create a profile using a classic e-mail server,
-you can send and receive messages without end-to-end encryption. 
-Such messages lacking end-to-end encryption are marked with an e-mail icon 
+you can send and receive messages with or without end-to-end encryption.
+Messages lacking end-to-end encryption are marked with an e-mail icon
 <img style="vertical-align:middle; width:1.2em; margin:1px" src="../assets/help/email-icon.png" alt="email"/>.
 
 ### How can I establish a chat with a new contact? {#howtoe2ee}


### PR DESCRIPTION
this small change may make it clearer that e2ee can be used by non-chatmail as well.

suggestion taken one-to-one from https://support.delta.chat/t/bring-back-avatars-redaction-modifying-member-list-to-unencrypted-chats/3977/38