### PR TITLE
fix blog links in mirrors

### DIFF
--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -3,7 +3,7 @@
 {% assign index = index | plus:1 %}
 {% if post.image and index <= 12 %}
 <div class="post-box">
-  <a href="{{ site.baseurl }}{{ post.url }}">
+  <a href="..{{ post.url }}">
     <div class="featured-image">
       <img src="{{ post.image }}" />
     </div>
@@ -12,7 +12,7 @@
   <p>
     <em>{{ post.date | date: "%B %d, %Y" }}</em> -
     {{ post.excerpt | strip_html }} 
-    <a href="{{ site.baseurl }}{{ post.url }}">Read on...</a>
+    <a href="..{{ post.url }}">Read on...</a>
   </p>
 </div>
 {% else %}
@@ -22,7 +22,7 @@
   {% endif %}
   <p>
     <em>{{ post.date | date: "%B %Y" }}</em> -
-    <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+    <a href="..{{ post.url }}">{{ post.title }}</a>
   </p>
 </div>
 {% endif %}


### PR DESCRIPTION
mirrors may be placed in a subdirectory,
this way, links continue to work;
we use the `../` approach also elsewhere, eg. on language selection, so this does not introduce smth new.

baseurl seems just not to be set,
and it is also not really used elsewhere.

may still be nice to hace mirrors on root,
however, with this PR this is less a prerequise.

closes https://github.com/deltachat/sysadmin/issues/197