### PR TITLE
serverguide: weaken discouragement of mailcow

### DIFF
--- a/en/serverguide.md
+++ b/en/serverguide.md
@@ -5,8 +5,8 @@ lang: en
 
 # How to Setup a Mail Server for Delta Chat
 
-> **Update:** This is outdated - we no longer recommend mailcow Servers,
-> but [Chatmail Relays](2023-12-13-chatmail) for chatting with Delta Chat.
+> **Update:** This is outdated - we now recommend
+> [Chatmail Relays](2023-12-13-chatmail) over mailcow servers for chatting with Delta Chat.
 > Read more [on GitHub](https://github.com/chatmail/relay) about how to set it up!
 
 Delta Chat is a chat messenger which runs on e-mail. This means we can use any

--- a/en/serverguide.md
+++ b/en/serverguide.md
@@ -6,8 +6,11 @@ lang: en
 # How to Setup a Mail Server for Delta Chat
 
 > **Update:** This is outdated - we now recommend
-> [Chatmail Relays](2023-12-13-chatmail) over mailcow servers for chatting with Delta Chat.
+> [Chatmail Relays](2023-12-13-chatmail) over mailcow servers for chatting with Delta Chat,
+> for faster delivery, reliable push notifications, and enforced message encryption.
 > Read more [on GitHub](https://github.com/chatmail/relay) about how to set it up!
+> mailcow is mostly an option
+> if you want to communicate with classic mail users who can't use encryption.
 
 Delta Chat is a chat messenger which runs on e-mail. This means we can use any
 e-mail server to run Delta Chat accounts. One e-mail server which is easy to


### PR DESCRIPTION
I got the following feedback from a friend:

> Im $hackspace kam grade auf warum deltachat kein mailcow mehr empfiehlt (https://delta.chat/de/serverguide). Nehme an das ist nur eine Empfehlung für das chatmail relay setup und nicht gegen mailcow? Wird anscheinend missverstanden, also ist evtl eine umformulierung wert.

For some use cases, mailcow is still a good option, and we should not *discourage* setting up mailcow, but *encourage* chatmail relays.