### PR TITLE
reorder help paragraphs

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -174,6 +174,17 @@ they will not see the green dot
 until one of the above conditions are met.
 
 
+### What do the ticks shown beside outgoing messages mean?
+
+- **One tick** means that the message was sent successfully to your provider.
+- **Two ticks** mean that at least one recipient's device
+  reported back to having received the message.
+- Recipients may have disabled read-receipts,
+  so even if you see only one tick, the message may have been read.
+- The other way round, two ticks do not automatically mean
+  that a human has read or understood the message ;)
+
+
 ### Correct typos and delete messages after sending {#edit}
 
 - You can edit the text of your messages after sending.
@@ -277,20 +288,6 @@ They will most likely also not be decryptable anymore
 
 - As an alternative, you can also "Mute" a group - doing so means you get all messages and 
   can still write, but are no longer notified of any new messages.
-
-
-### What do the ticks shown beside outgoing messages mean?
-
-- **One tick** means that the message was sent successfully to your provider.
-- **Two ticks** mean that at least one recipient's device
-  reported back to having received the message.
-- Recipients may have disabled read-receipts,
-  so even if you see only one tick, the message may have been read.
-- The other way round, two ticks do not automatically mean
-  that a human has read or understood the message ;)
-
-
-
 
 
 ## Instant message delivery and Push Notifications {#instant-delivery}

--- a/en/help.md
+++ b/en/help.md
@@ -1090,14 +1090,6 @@ folder might go away in the future. It was introduced at a time where there was
 no Delta Chat Desktop client available on all platforms.
 
 
-### Why can I choose not to watch the DeltaChat folder?
-
-Some people use Delta Chat as a regular email client, and want to use the Inbox
-folder for their mail, instead of the DeltaChat folder. If you disable "Watch
-DeltaChat folder", you should also disable "move chat messages to DeltaChat".
-Otherwise, deleting messages or multi-device setups might not work properly.
-
-
 ### Why can I choose to only watch the DeltaChat folder?
 
 This is an experimental setting for some people who are experimenting with

--- a/en/help.md
+++ b/en/help.md
@@ -945,35 +945,7 @@ To learn more about this the details behind this, [read our blogpost on
 it](https://delta.chat/en/2022-09-14-aeap).
 
 
-## Miscellaneous
-
-### Which permissions does Delta Chat need?
-
-Depending on the operating system in use,
-you may be asked to grant permissions to the app.
-This is what Delta Chat does with these permissions:
-
-- Camera *(can be disallowed)*
-  - take pictures and videos: for sending Photos
-- Contacts *(can be disallowed)*
-  - read your contacts: to discover contacts to chat with
-- Location *(can be disallowed)*
-  - access approximate location (network location sources): for the location streaming feature
-  - access precise location (GPS and network location sources): for the location streaming feature
-- Microphone *(can be disallowed)*
-  - record audio: for audio messages
-- Storage *(can be disallowed)*
-  - modify or delete the contents of your SD card: to download message attachments
-  - read the contents of your SD card: to share files with your contacts
-- Other app capabilities
-  - change your audio settings: so you can choose ring tones and volume for notifications and audio messages
-  - run at startup: so you don't have to start Delta Chat manually
-  - control vibration: for notifications
-  - view network connections: to connect to your E-Mail provider
-  - prevent phone from sleeping: so you can easier copy the security code during the Autocrypt Setup Message
-  - have full network access: to connect to your E-Mail provider
-  - view Wi-Fi connections: to connect to your E-Mail provider
-  - ask to ignore battery optimisations: for achieving "instant message delivery"
+## Advanced
 
 
 ### Does Delta Chat work with _my_ e-mail-provider?
@@ -1118,6 +1090,41 @@ In this case, Delta Chat doesn't need to watch the Inbox, and it's enough to onl
 - Delta Chat can end-to-end-encrypt through any e-mail provider with any
   [Autocrypt-enabled e-mail app](https://autocrypt.org/dev-status.html).
 
+### I'm interested in the technical details. Can you tell me more?
+
+- See [Standards used in Delta Chat]({% include standards-url %}).
+
+
+## Miscellaneous
+
+### Which permissions does Delta Chat need?
+
+Depending on the operating system in use,
+you may be asked to grant permissions to the app.
+This is what Delta Chat does with these permissions:
+
+- Camera *(can be disallowed)*
+  - take pictures and videos: for sending Photos
+- Contacts *(can be disallowed)*
+  - read your contacts: to discover contacts to chat with
+- Location *(can be disallowed)*
+  - access approximate location (network location sources): for the location streaming feature
+  - access precise location (GPS and network location sources): for the location streaming feature
+- Microphone *(can be disallowed)*
+  - record audio: for audio messages
+- Storage *(can be disallowed)*
+  - modify or delete the contents of your SD card: to download message attachments
+  - read the contents of your SD card: to share files with your contacts
+- Other app capabilities
+  - change your audio settings: so you can choose ring tones and volume for notifications and audio messages
+  - run at startup: so you don't have to start Delta Chat manually
+  - control vibration: for notifications
+  - view network connections: to connect to your E-Mail provider
+  - prevent phone from sleeping: so you can easier copy the security code during the Autocrypt Setup Message
+  - have full network access: to connect to your E-Mail provider
+  - view Wi-Fi connections: to connect to your E-Mail provider
+  - ask to ignore battery optimisations: for achieving "instant message delivery"
+
 
 ### How can I delete my account? {#remove-account}
 
@@ -1145,12 +1152,6 @@ If you want to continue using a classic e-mail account with other apps,
 but uninstall Delta Chat,
 it is recommended to leave any group chat before uninstalling Delta Chat.
 Otherwise you might receive undecryptable messages from those group chats.
-
-
-### I'm interested in the technical details. Can you tell me more?
-
-- See [Standards used in Delta Chat]({% include standards-url %}).
-
 
 
 ### Where can my friends find Delta Chat?

--- a/en/help.md
+++ b/en/help.md
@@ -917,21 +917,6 @@ and will very probably be replaced by something else, stay tuned :)
   a message, but also appears on the map.
 
 
-### Why can I choose to only watch the DeltaChat folder?
-
-This is an experimental setting for some people who are experimenting with
-server-side rules. Not all providers support this, but with some you can move
-all mails with a "Chat-Version" header to the DeltaChat folder. Normally, this
-would be done by the Delta Chat app.
-
-Enabling "Only Fetch from DeltaChat folder" makes sense if you have **both**:
-
-- enabled a server-side rule to move all messages with Chat-Version header to the DeltaChat folder, and
-- have set the "Show classic emails" setting to "no, chats only".
-
-In this case, Delta Chat doesn't need to watch the Inbox, and it's enough to only watch the DeltaChat folder.
-
-
 ### How can I use a different e-mail address with my profile?
 
 Note: 
@@ -1111,6 +1096,21 @@ Some people use Delta Chat as a regular email client, and want to use the Inbox
 folder for their mail, instead of the DeltaChat folder. If you disable "Watch
 DeltaChat folder", you should also disable "move chat messages to DeltaChat".
 Otherwise, deleting messages or multi-device setups might not work properly.
+
+
+### Why can I choose to only watch the DeltaChat folder?
+
+This is an experimental setting for some people who are experimenting with
+server-side rules. Not all providers support this, but with some you can move
+all mails with a "Chat-Version" header to the DeltaChat folder. Normally, this
+would be done by the Delta Chat app.
+
+Enabling "Only Fetch from DeltaChat folder" makes sense if you have **both**:
+
+- enabled a server-side rule to move all messages with Chat-Version header to the DeltaChat folder, and
+- have set the "Show classic emails" setting to "no, chats only".
+
+In this case, Delta Chat doesn't need to watch the Inbox, and it's enough to only watch the DeltaChat folder.
 
 
 ### Is Delta Chat compatible with Proton Mail / Tutanota / Criptext?

--- a/en/help.md
+++ b/en/help.md
@@ -868,83 +868,6 @@ extendable messenger.
   Forum](https://support.delta.chat/c/webxdc/20).
 
 
-## Experimental Features
-
-We are very grateful for feedback on these features - do you want to share
-your ideas? Join the [Forum](https://support.delta.chat) to contribute. 
-You may conveniently login via Delta Chat and a QR code scan,
-another rather stable experiment we run on the side (sic!).
-
-### How can I use audio/video calls with Delta Chat?
-
-- To turn on audio/video calls, go to the "experimental features" section in
-  the advanced settings and choose a "Video Chat Instance". 
-- When you invite others to a video chat, it is opened in your browser/app at
-  once. The others receive an e-mail with a link to the video chat. 
-  This way, it is also compatible if your chat partners don't use Delta Chat.
-- Note that there is no ring tone on the other side, and your chat partners
-  will not get interrupted by a video chat invite.
-- You can use any video chat service which allows joining by link. Just add the
-  link in the settings.
-- For example, to use the flagship Jitsi Meet instance, you could enter
-  `https://meet.jit.si/$ROOM`. The `$ROOM` variable will be a random value;
-  this way, you will have a new random Jitsi room every time you call someone.
-
-
-### What are Broadcast Lists and how can I use them?
-
-With a Broadcast List you can send a message to many recipients at once;
-the recipients cannot reply in that list.
-Broadcast lists are still highly experimental
-and will very probably be replaced by something else, stay tuned :)
-
-
-### How can I share my location with my chat partners?
-
-- You can turn on location streaming in the "experimental features" section of
-  the advanced settings.
-- Now, if you want to share your location in a chat, go to "attach" and select
-  "location". You can now set a time frame in which your location will be
-  streamed to your chat partners, between 5 minutes and 6 hours.
-- When your location changes, the others in the chat can view it on a map in
-  the chat.
-- To see the map and view locations of others, you need to turn on the feature
-  in the advanced settings.
-- This feature will not share your location with anyone except your chat partners.
-  Map tiles are downloaded from [OpenStreetMap](https://openstreetmap.org).
-- On desktop, the OS typically can't determine your location. Instead you can
-  right click on the map and describe a location, which is sent to the chat as
-  a message, but also appears on the map.
-
-
-### How can I use a different e-mail address with my profile?
-
-Note: 
-Changing email addresses is temporarily disabled
-because of ongoing changes to the DeltaChat core.
-It should be available again in a few months.
-
-1. Change your address in “Settings → Advanced → Password and Account” and
-   enter the password of your new e-mail account (and if necessary, server settings).
-   You will get an information notice about the fact that you are moving to a new address. 
-   An additional notice will also show up in your "Device messages" chat. 
-
-2. If possible, let your old e-mail provider forward all messages to your new address.
-
-3. Tell your contacts that you changed your address. 
-   Writing to guaranteed end-to-end encrypted chats and groups,
-   will make them notice your move automatically 
-   and they will continue chatting with you using your new address. 
-
-Note that Delta Chat will not retrieve messages anymore from your old e-mail provider.
-If you didn't configure your e-mail provider to forward messages (step 2.) 
-only those contacts to whom you sent a message in a guaranteed end-to-end encrypted chat
-will send messages to your new address. 
-
-To learn more about this the details behind this, [read our blogpost on
-it](https://delta.chat/en/2022-09-14-aeap).
-
-
 ## Advanced
 
 
@@ -1093,6 +1016,83 @@ In this case, Delta Chat doesn't need to watch the Inbox, and it's enough to onl
 ### I'm interested in the technical details. Can you tell me more?
 
 - See [Standards used in Delta Chat]({% include standards-url %}).
+
+
+## Experimental Features
+
+We are very grateful for feedback on these features - do you want to share
+your ideas? Join the [Forum](https://support.delta.chat) to contribute.
+You may conveniently login via Delta Chat and a QR code scan,
+another rather stable experiment we run on the side (sic!).
+
+### How can I use audio/video calls with Delta Chat?
+
+- To turn on audio/video calls, go to the "experimental features" section in
+  the advanced settings and choose a "Video Chat Instance".
+- When you invite others to a video chat, it is opened in your browser/app at
+  once. The others receive an e-mail with a link to the video chat.
+  This way, it is also compatible if your chat partners don't use Delta Chat.
+- Note that there is no ring tone on the other side, and your chat partners
+  will not get interrupted by a video chat invite.
+- You can use any video chat service which allows joining by link. Just add the
+  link in the settings.
+- For example, to use the flagship Jitsi Meet instance, you could enter
+  `https://meet.jit.si/$ROOM`. The `$ROOM` variable will be a random value;
+  this way, you will have a new random Jitsi room every time you call someone.
+
+
+### What are Broadcast Lists and how can I use them?
+
+With a Broadcast List you can send a message to many recipients at once;
+the recipients cannot reply in that list.
+Broadcast lists are still highly experimental
+and will very probably be replaced by something else, stay tuned :)
+
+
+### How can I share my location with my chat partners?
+
+- You can turn on location streaming in the "experimental features" section of
+  the advanced settings.
+- Now, if you want to share your location in a chat, go to "attach" and select
+  "location". You can now set a time frame in which your location will be
+  streamed to your chat partners, between 5 minutes and 6 hours.
+- When your location changes, the others in the chat can view it on a map in
+  the chat.
+- To see the map and view locations of others, you need to turn on the feature
+  in the advanced settings.
+- This feature will not share your location with anyone except your chat partners.
+  Map tiles are downloaded from [OpenStreetMap](https://openstreetmap.org).
+- On desktop, the OS typically can't determine your location. Instead you can
+  right click on the map and describe a location, which is sent to the chat as
+  a message, but also appears on the map.
+
+
+### How can I use a different e-mail address with my profile?
+
+Note:
+Changing email addresses is temporarily disabled
+because of ongoing changes to the DeltaChat core.
+It should be available again in a few months.
+
+1. Change your address in “Settings → Advanced → Password and Account” and
+   enter the password of your new e-mail account (and if necessary, server settings).
+   You will get an information notice about the fact that you are moving to a new address.
+   An additional notice will also show up in your "Device messages" chat.
+
+2. If possible, let your old e-mail provider forward all messages to your new address.
+
+3. Tell your contacts that you changed your address.
+   Writing to guaranteed end-to-end encrypted chats and groups,
+   will make them notice your move automatically
+   and they will continue chatting with you using your new address.
+
+Note that Delta Chat will not retrieve messages anymore from your old e-mail provider.
+If you didn't configure your e-mail provider to forward messages (step 2.)
+only those contacts to whom you sent a message in a guaranteed end-to-end encrypted chat
+will send messages to your new address.
+
+To learn more about this the details behind this, [read our blogpost on
+it](https://delta.chat/en/2022-09-14-aeap).
 
 
 ## Miscellaneous

--- a/en/help.md
+++ b/en/help.md
@@ -221,6 +221,34 @@ They will most likely also not be decryptable anymore
 (as long as they were encrypted in the first place).
 
 
+### What happens if I turn on "Delete old messages from server"?
+
+- By default, Delta Chat stores all messages locally on your device.
+  If you  e.g. want to save storage space at your mail provider,
+  you can configure  Delta Chat
+  to delete old already-received messages on the server automatically.
+  They still remain on your device until you delete them there, too.
+
+- To turn it on, go to **Delete Old Messages → Delete Messages from Server**
+  in the "Chats and Media" settings.
+  You can set a timeframe between "At once" and "After 1 year".
+  All e-mails received by Delta Chat will be deleted from the server after this timeframe.
+
+- Note that if you use Delta Chat on more than one device,
+  you need to leave the message on the server with a sufficient timeframe
+  so that the other device(s) can download them, too.
+
+
+### What happens if I turn on "Delete old messages from device"? {#delold}
+
+- If you want to save storage on your device, you can choose to delete old
+  messages automatically.
+- To turn it on, go to "delete old messages from device" in the "Chats & Media"
+  settings. You can set a timeframe between "after an hour" and "after a year";
+  this way, *all* messages will be deleted from your device as soon as they are
+  older than that.
+
+
 ## Groups
 
 ### Creation of a group
@@ -262,32 +290,7 @@ They will most likely also not be decryptable anymore
   that a human has read or understood the message ;)
 
 
-### What happens if I turn on "Delete old messages from server"?
 
-- By default, Delta Chat stores all messages locally on your device.
-  If you  e.g. want to save storage space at your mail provider,
-  you can configure  Delta Chat
-  to delete old already-received messages on the server automatically.
-  They still remain on your device until you delete them there, too.
-
-- To turn it on, go to **Delete Old Messages → Delete Messages from Server**
-  in the "Chats and Media" settings.
-  You can set a timeframe between "At once" and "After 1 year".
-  All e-mails received by Delta Chat will be deleted from the server after this timeframe.
-
-- Note that if you use Delta Chat on more than one device,
-  you need to leave the message on the server with a sufficient timeframe
-  so that the other device(s) can download them, too.
-
-
-### What happens if I turn on "Delete old messages from device"? {#delold}
-
-- If you want to save storage on your device, you can choose to delete old
-  messages automatically. 
-- To turn it on, go to "delete old messages from device" in the "Chats & Media"
-  settings. You can set a timeframe between "after an hour" and "after a year";
-  this way, *all* messages will be deleted from your device as soon as they are
-  older than that.
 
 
 ## Instant message delivery and Push Notifications {#instant-delivery}


### PR DESCRIPTION
this PR is a reorders some paragraphs to the sections "Basics", Groups, Advanced, Experimental Misc.

- classic Email related things are split off "Misc" and moved to "Advanced". idea is to really have all non-recommended workflows here 
- "Green Ticks" explanations are moved from "Groups" to "Basic" (they are not for groups only)
- "Only Watch DeltaChat folder" is moved to "Advanced" (where corresponding options are)
- "Watch DeltaChat folder" description is removed, the option itself was removed in 2022

this PR does not want to reword anything.

in a subsequent PR, "Experimental" should become a single paragraph of "Advanced", describing "Experiments" on a meta-level (may not work, is buggy, may be changed or removed) and then pointing to a corresponding section in the forum (in the past, we did not manage to really keep the faq up to date for that)

i'd also like to have less room for "classic" email, but that is also for a subsequent PR