### PR TITLE
redirect /chatmail to chatmail.at

### DIFF
--- a/chatmail.html
+++ b/chatmail.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<meta http-equiv="refresh" content="1; url=en/chatmail">
+<meta http-equiv="refresh" content="1; url=https://chatmail.at/relays">
 <script src="redirect.js"></script>

--- a/chatmail.html
+++ b/chatmail.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
 <meta http-equiv="refresh" content="1; url=https://chatmail.at/relays">
-<script src="redirect.js"></script>
+<script>window.location.href = "https://chatmail.at/relays"</script>

--- a/redirect.js
+++ b/redirect.js
@@ -18,11 +18,11 @@ function getLanguageFolder() {
   return 'en'
 }
 
-function getRedirectFile() {
+function getRedirectParam() {
   var metaTag = document.querySelector('meta[http-equiv="refresh"]');
   var content = metaTag.getAttribute('content');
 
-  var urlMatch = content.match(/url\s*=\s*en\/([^;]+)/i);
+  var urlMatch = content.match(/url\s*=\s*([^;]+)/i);
   if (urlMatch && urlMatch[1]) {
     return urlMatch[1].trim();
   }
@@ -30,5 +30,16 @@ function getRedirectFile() {
   return '';
 }
 
-var newLocation = getLanguageFolder() + '/' + getRedirectFile() + window.location.hash;
+function getAbsRedirect() {
+  var param = getRedirectParam();
+
+  var urlMatch = param.match(/en\/(.+)/i);
+  if (urlMatch && urlMatch[1]) {
+    return getLanguageFolder() + '/' + urlMatch[1] + window.location.hash;
+  }
+
+  return param;
+}
+
+var newLocation = getAbsRedirect();
 window.location.href = newLocation;

--- a/redirect.js
+++ b/redirect.js
@@ -18,11 +18,11 @@ function getLanguageFolder() {
   return 'en'
 }
 
-function getRedirectParam() {
+function getRedirectFile() {
   var metaTag = document.querySelector('meta[http-equiv="refresh"]');
   var content = metaTag.getAttribute('content');
 
-  var urlMatch = content.match(/url\s*=\s*([^;]+)/i);
+  var urlMatch = content.match(/url\s*=\s*en\/([^;]+)/i);
   if (urlMatch && urlMatch[1]) {
     return urlMatch[1].trim();
   }
@@ -30,16 +30,5 @@ function getRedirectParam() {
   return '';
 }
 
-function getAbsRedirect() {
-  var param = getRedirectParam();
-
-  var urlMatch = param.match(/en\/(.+)/i);
-  if (urlMatch && urlMatch[1]) {
-    return getLanguageFolder() + '/' + urlMatch[1] + window.location.hash;
-  }
-
-  return param;
-}
-
-var newLocation = getAbsRedirect();
+var newLocation = getLanguageFolder() + '/' + getRedirectFile() + window.location.hash;
 window.location.href = newLocation;


### PR DESCRIPTION
for deleting en/chatmail: it was hardcoded in iOS at https://github.com/deltachat/deltachat-ios/pull/2860 - as we may not not want a redirect inside the local folders, i'd leave that for now and cleanup at some later point