### PR TITLE
xstore@testrun.org deprecation notice

### DIFF
--- a/_posts/2023-08-11-xstore.md
+++ b/_posts/2023-08-11-xstore.md
@@ -33,7 +33,7 @@ and how the whole thing works.
 
 ## How to start
 
-> **Update:** now you can simply pick webxdc apps in the app
+> **Update:** You can now simply pick webxdc apps in the app
 > or download them from <https://webxdc.org/apps/>,
 > so xstore@testrun.org has been deactivated.
 

--- a/_posts/2023-08-11-xstore.md
+++ b/_posts/2023-08-11-xstore.md
@@ -33,6 +33,10 @@ and how the whole thing works.
 
 ## How to start
 
+> **Update:** now you can simply pick webxdc apps in the app
+> or download them from <https://webxdc.org/apps/>,
+> so xstore@testrun.org has been deactivated.
+
 <img src="../assets/blog/2023-08-xstore-start.png" width="240" style="float:right; margin-left:1em;" />  
 With Delta Chat already working it's dead simple to **start**:
 


### PR DESCRIPTION
Now that there is an in-app-picker, barely anyone uses xstore@testrun.org anyway.