### PR TITLE
"add second device" works with clipboard as well

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -527,7 +527,12 @@ One device is not needed for the other to work.
 - Delta Chat is **already logged in** on the destination device?
   You can use multiple profiles per device, just [add another profile](#multiple-accounts)
 
-- If you still have problems or if you **cannot scan a QR code**
+- **No camera?** on the first device, click "Copy to Clipboard".
+  Do not close the screen.
+  Transfer the clipboard content to the second device (e.g. by another chat or file transfer),
+  and paste it there from "Add as Second Device / Paste from Clipboard"
+
+- If you still have problems
   try the **manual transfer** described below
 
 


### PR DESCRIPTION
briefly mention the clipboard option,
no need to go into all details and click paths,
it is complex, if one does not have an idea how clipboard etc. works, ppl anyway need help.

doing transfer over clipboard is preferrable to transferring backup files - it is easier, and usually more secure.

it is still fine to have that at the pretty end,
other issues are still more important,
surely not all towers have a cam, but many do, and most notebooks as well. the bias in our circles may be different, of course :)