### PR TITLE
offer an expert way to inspect keys

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -868,7 +868,7 @@ We do not recommend or offer users to perform manual key management.
 We want to ensure that security audits can focus on a few proven cryptographic algorithms
 instead of the full breadth of possible algorithms allowed with OpenPGP.
 If you want to extract your OpenPGP key, there only is an expert method:
-you need to look it up in the "keypairs" sqlite table of a profile backup tar-file.
+you need to look it up in the "keypairs" SQLite table of a profile backup tar-file.
 
 
 ### Was Delta Chat independently audited for security vulnerabilities? {#security-audits}

--- a/en/help.md
+++ b/en/help.md
@@ -863,12 +863,13 @@ the connection is safe.
 
 No. 
 
-Delta Chat generates secure OpenPGP keys according to the Autocrypt specification 1.1. 
-You can export your private key but you can not import additional private keys. 
+Delta Chat generates secure OpenPGP keys according to the Autocrypt specification 1.1.
+We do not recommend or offer users to perform manual key management.
+We want to ensure that security audits can focus on a few proven cryptographic algorithms
+instead of the full breadth of possible algorithms allowed with OpenPGP.
+If you want to extract your OpenPGP key, there only is an expert method:
+you need to look it up in the "keypairs" sqlite table of a profile backup tar-file.
 
-In general, we do not recommend or offer users to perform manual key management. 
-We want to ensure that security audits can focus on a few proven cryptographic algorithms 
-instead of the full breadth of possible algorithms allowed with OpenPGP. 
 
 ### Was Delta Chat independently audited for security vulnerabilities? {#security-audits}
 


### PR DESCRIPTION
this PR chances the paragraph about key handling, esp. offering a rough description how to extract them if you're an expert. we do not want to have precise command line instructions, click paths, or details about the format here - either you know where to backup, what tar is, how to browse a sqlite database, and that the key is obviously in binary format - or you do not, but then, it is probably also better to not mess around with keys. also going to explain mode here, again, brings us to the position where we care about smth that we before said, we do not support.

the paragraph is a compromise in the current state of the the project, and it paves the way to remove the "settings / encryption" sections alltogether, also on desktop.

this was discussed yesterday @hpk42, who also did the wordings