### PR TITLE
remove 'email' reference from homepage, correct chatmail link

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -7,7 +7,7 @@ lang: en
 
 💬 Reliable instant messaging with multi-profile and multi-device support
 
-⚡️ Sign up to [secure fast chatmail servers](chatmail) or use [classic e-mail servers](https://providers.delta.chat/)
+⚡️ Sign up to secure and interoperable [chatmail relays](https://chatmail.at/relays)
 
 🥳 Interactive [web apps in chats](https://webxdc.org/) for gaming and collaboration
 


### PR DESCRIPTION
this PR removes "email" wording from the homepage, as everywhere else. this was somehow overseen up to no, thanks @adbenitez for pointing to it.

moreover, this fixes the chatmail link

i pick up the wording here that is already use in the help