### PR TITLE
layout "Archived" and "Request" marks

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -62,7 +62,8 @@ If you add each other to [groups](#groups), end-to-end encryption will be establ
 As being a private messenger,
 only friends and family you [share your QR code or invite link with](#howtoe2ee) can write to you.
 
-Your friends may share your contact with other friends, this appears as a **request**.
+Your friends may share your contact with other friends,
+this appears as <b style="border: 1px solid currentColor; padding: 0 3px; font-size:90%">Request</b>
 
 - You need to **accept** the request before you can reply.
 
@@ -132,7 +133,8 @@ Use these tools to organize your chats and keep everything in its place:
 - **Mute chats** if you do not want to get notifications for them. Muted chats stay in place and you can also pin a muted chat.
 
 - **Archive chats** if you do not want to see them in your chat list any longer.
-  Archived chats remain accessible above the chat list or via search. 
+  They remain accessible above the chat list or via search
+  and are marked by <b style="border: 1px solid currentColor; padding: 0 3px; font-size:90%">Archived</b>
 
 - When an archived chat gets a new message, unless muted, it will **pop out of the archive** and back into your chat list.
   **Muted chats stay archived** until you unarchive them manually.


### PR DESCRIPTION
show texts "Archived" and "Request" in a box, similar to the layout in the the app:

<img width="678" height="164" alt="Screenshot 2025-12-16 at 18 17 03" src="https://github.com/user-attachments/assets/2ec9671d-5984-4e92-9348-7b6601c63250" /><br><br>

this is on-purpose not using css class, so that it is easily integrated in the offline help, similar to some minor padding of the symbols used elsewhere.

in general, the symbols shown are not exhaustive, but many more important/frequent/uncommon are there meanwhile :)
