### PR TITLE
remove serverguide from active translations

### DIFF
--- a/tools/.tx/config
+++ b/tools/.tx/config
@@ -7,12 +7,6 @@ source_file = translations/delta-chat-pages.blogpo/en.po
 source_lang = en
 type        = PO
 
-[o:delta-chat:p:delta-chat-pages:r:serverguidepo]
-file_filter = translations/delta-chat-pages.serverguidepo/<lang>.po
-source_file = translations/delta-chat-pages.serverguidepo/en.po
-source_lang = en
-type        = PO
-
 [o:delta-chat:p:delta-chat-pages:r:community-standardspo]
 file_filter = translations/delta-chat-pages.community-standardspo/<lang>.po
 source_file = translations/delta-chat-pages.community-standardspo/en.po

--- a/tools/t-dance.sh
+++ b/tools/t-dance.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-sfiles=(blog contribute community-standards donate download help imprint index references verify-downloads serverguide)
+sfiles=(blog contribute community-standards donate download help imprint index references verify-downloads)
 tlangs=(ca cs de es fr gl id it nl pl pt pt_BR ru sk sq tr uk zh_CN)  # do not add `en` to this list
 
 


### PR DESCRIPTION
the existing translations stay as is "frozen" for now,
but as the file is legacy it does not make sense
to have translations as "todo" for new or existing languages -
esp. as translations of the big file is a lot of work (only help is larger!) -
and esp. as these technical document usually are not translated at all.