### PR TITLE
try fix: libresilient: don't crash when CacheStorage API is not available.

### DIFF
--- a/libresilient.js
+++ b/libresilient.js
@@ -8,8 +8,9 @@
 
 // check if the browser implements ServiceWorkers API
 if ('serviceWorker' in navigator) {
-    
-    if (navigator.serviceWorker.controller) {
+    if (!caches) {
+      console.error('LibResilient: CacheStorage API is not available.')
+    } else if (navigator.serviceWorker.controller) {
         // Service worker already registered.
         console.log('A Service Worker is already registered.')
     } else {

--- a/libresilient.js
+++ b/libresilient.js
@@ -8,7 +8,7 @@
 
 // check if the browser implements ServiceWorkers API
 if ('serviceWorker' in navigator) {
-    if (!caches) {
+    if (typeof caches === 'undefined') {
       console.error('LibResilient: CacheStorage API is not available.')
     } else if (navigator.serviceWorker.controller) {
         // Service worker already registered.


### PR DESCRIPTION
Try to fix lib resilient crash by not starting it when the CacheStorage API is not available.

This pr does not implement a fallback method for extra resilience and I haven't explored if it would event be possible to implement a fallback without the CacheStorage API.
It just doesn't load the libresilient code if the required CacheStorage API is unavaible and thus does not show the crash/error.
