### PR TITLE
Add link preview information to index.html redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,12 @@
 <!DOCTYPE html>
+<meta name="description" content="Delta Chat is a decentralized and secure messenger app 💬 Reliable instant messaging with multi-profile and multi-device support ⚡️ Sign up to secure and interoperable chatmail relays 🥳 Interactive ..." />
+<meta name="keywords" content="delta chat, chatmail, messenger, download delta chat" />
+<meta property="og:title" content="Delta Chat: Delta Chat, decentralized secure messenger">
+<meta property="og:description" content="Delta Chat is a decentralized and secure messenger app 💬 Reliable instant messaging with multi-profile and multi-device support ⚡️ Sign up to secure and interoperable chatmail relays 🥳 Interactive ...">
+<meta property="og:image" content="https://delta.chat/assets/home/intro1.png">
+<meta property="og:url" content="https://delta.chat{{ page.url }}">
+<meta name="fediverse:creator" content="@delta@chaos.social">
+<meta name="twitter:card" content="summary">
+
 <meta http-equiv="refresh" content="1; url=en/">
 <script src="redirect.js"></script>


### PR DESCRIPTION
Otherwise old cached preview without image is displayed in Mastodon: https://support.delta.chat/t/delta-chat-uses-the-wording-e-mail-messenger-when-linked-on-mastodon/4647