### PR TITLE
add a page for removed "Move to DeltaChat folder"

### DIFF
--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -23,9 +23,7 @@ To see how the change affects you,
 
 1. Open Delta Chat, go to **Settings → Advanced**
 
-2. **Disable "Move automatically to DeltaChat Folder"**,  
-   **disable "Only fetch from DeltaChat Folder"** and  
-   **set "Show Classic Emails" to "All"**.
+2. **Disable "Move automatically to DeltaChat Folder"**
 
 If you do not do this explicitly today,
 this will happen implicitly the next weeks.
@@ -43,18 +41,23 @@ the encrypted messages in the Inbox may be annoying.
 
 If so, you should change the profile as follows:
 
-1. Open Delta Chat, go to **Settings → Advanced → Relays**
+1. Open Delta Chat, go to **Settings → Advanced**
 
-2. Tap **Add Relay**
+2. **Disable "Only fetch from DeltaChat Folder"** and  
+   **set "Show Classic Emails" to "All"**
 
-3. Go to <https://chatmail.at/relays>, and select one of the relays shown there
+3. Go to **Settings → Advanced → Relays**
 
-4. **Scan the QR code** shown on the relay's website
+4. Tap **Add Relay**
+
+5. Go to <https://chatmail.at/relays>, and select one of the relays shown there
+
+6. **Scan the QR code** shown on the relay's website
 
     - **If you cannot scan,** right click or long tap the QR code,
       select "Copy Link" and paste that to the scanner window
 
-5. Tab the newly added relay so that it becomes **Default**
+7. Tab the newly added relay so that it becomes **Default**
 
 Then, continue chatting, **your contacts will learn the new relay** over time -
 until then, you are still reachable on the old email

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -9,7 +9,7 @@ lang: en
 > This page is a service for users still using legacy options.
 >
 > If you did not get a warning,
-> go for for something else, [maybe play a game inside Delta Chat](help#webxdc) :)
+> go for something else, [maybe play a game inside Delta Chat](help#webxdc) :)
 
 
 ### Required Steps

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -84,5 +84,5 @@ and there is no need to enter an email address - let alone a phone number.
 Finally removing the legacy "Shared Profile" options is the next logical step -
 it makes the app clearer and easier to support,
 freeing up developer mind space to to much more impactful things -
-as multi relay, channels calls.
+as multi relay, channels and calls.
 And, of course fixing bugs, making Delta Chat a truely stable experience

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -67,7 +67,7 @@ which will then stop cluttering your classic Inbox with encrypted messages
 
 We want Delta Chat users to have a easy, reliable and secure messenger experience.
 
-Sharing email addresses with classic email apps was the default in the early years,
+Using the same email addresses in Delta Chat and in classic email apps was the default in the early years,
 however, turned out to stand in the way of these goals.
 E.g. notifications could not be made reliable, onboarding was complex,
 encrypted messages are annoying in the inbox - and plaintext are not what we want to have in Delta Chat by default.
@@ -76,12 +76,12 @@ Also, while we keep on using email technically,
 this is nothing the average user should care about -
 similar to other messenger using https under the hood.
 
-Therefore, by default, user get a dedicated profile since quite some time
+Therefore, by default, user get a dedicated, exclusive profile since quite some time
 and there is no need to enter an email address - let alone a phone number.
 
 **Since then, the onboarding is one of the easiest around - you only need to enter a name 🎉**
 
-Finally removing the legacy "Shared Profile" options is the next logical step -
+Finally removing the legacy options is the next logical step -
 it makes the app clearer and easier to support,
 freeing up developer mind space to to much more impactful things -
 as multi relay, channels and calls.

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -47,7 +47,7 @@ If so, you should switch to a dedicated chat profile as follows:
 
 2. Tap **Add Relay**
 
-3. Go to https://chatmail.at/relays, and select one of the relays shown there
+3. Go to <https://chatmail.at/relays>, and select one of the relays shown there
 
 4. **Scan the QR code** shown on the relay's website
 

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -43,7 +43,7 @@ If so, you should change the profile as follows:
 
 1. Open Delta Chat, go to **Settings → Advanced**
 
-2. **Disable "Only fetch from DeltaChat Folder"** and  
+2. If not yet the case, **disable "Only fetch from DeltaChat Folder"** and  
    **set "Show Classic Emails" to "All"**
 
 3. Go to **Settings → Advanced → Relays**

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -1,0 +1,86 @@
+---
+title: Use a Dedicated Chat Profile
+lang: en
+---
+
+
+## Use a Dedicated Chat Profile
+
+> This page is a service for users still using legacy options.
+>
+> If you did not get a warning,
+> go for for something else, [maybe play a game inside Delta Chat](help#webxdc) :)
+
+
+### Required Steps
+
+The option "Move automatically to DeltaChat Folder"
+as well as other legacy options
+will be removed in the next weeks.
+
+To see how the change affects you,
+**already today**, do the following steps:
+
+1. Open Delta Chat, go to **Settings → Advanced**
+
+2. **Disable "Move automatically to DeltaChat Folder"**,  
+   **disable "Only fetch from DeltaChat Folder"** and  
+   **set "Show Classic Emails" to "All"**.
+
+If you do not do this explicitly today,
+this will happen implicitly the next weeks.
+
+
+### Optional Steps
+
+If you are using the email for chatting only,
+and not using another email app for that address beside Delta Chat,
+the following steps are not needed.
+
+**Only if you share the same email** for chatting and classic usage,
+which is discouraged since some time,
+the encrypted messages in the Inbox may be annoying.
+
+If so, you should switch to a dedicated chat profile as follows:
+
+1. Open Delta Chat, go to **Settings → Advanced → Relays**
+
+2. Tap **Add Relay**
+
+3. **Scan the QR code** shown on <https://nine.testrun.org>
+
+    - **If you cannot scan,** right click or long tap [here](dcaccount:https://nine.testrun.org/new),
+      select "Copy Link" and paste that to the scanner window
+
+4. Tab the newly added relay so that it becomes **Default**
+
+Then, continue chatting, **your contacts will learn the new relay** over time -
+until then, you are still reachable on the old email
+
+**Some weeks later,** you can remove the old email, 
+which will then stop cluttering your classic Inbox with encrypted messages
+
+
+## Background
+
+We want Delta Chat users to have a easy, reliable and secure messenger experience.
+
+Sharing email addresses with classic email apps was the default in the early years,
+however, turned out to stand in the way of these goals.
+E.g. notifications could not be made reliable, onboarding was complex,
+encrypted messages are annoying in the inbox - and plaintext are not what we want to have in Delta Chat by default.
+
+Also, while we keep on using email technically,
+this is nothing the average user should care about -
+similar to other messenger using https under the hood.
+
+Therefore, by default, user get a dedicated profile since quite some time
+and there is no need to enter an email address - let alone a phone number.
+
+**Since then, the onboarding is one of the easiest around - you only need to enter a name 🎉**
+
+Finally removing the legacy "Shared Profile" options is the next logical step -
+it makes the app clearer and easier to support,
+freeing up developer mind space to to much more impactful things -
+as multi relay, channels calls.
+And, of course fixing bugs, making Delta Chat a truely stable experience

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -47,12 +47,14 @@ If so, you should switch to a dedicated chat profile as follows:
 
 2. Tap **Add Relay**
 
-3. **Scan the QR code** shown on <https://nine.testrun.org>
+3. Go to https://chatmail.at/relays, and select one of the relays shown there
 
-    - **If you cannot scan,** right click or long tap [here](dcaccount:https://nine.testrun.org/new),
+4. **Scan the QR code** shown on the relay's website
+
+    - **If you cannot scan,** right click or long tap the QR code,
       select "Copy Link" and paste that to the scanner window
 
-4. Tab the newly added relay so that it becomes **Default**
+5. Tab the newly added relay so that it becomes **Default**
 
 Then, continue chatting, **your contacts will learn the new relay** over time -
 until then, you are still reachable on the old email

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -41,7 +41,7 @@ the following steps are not needed.
 which is discouraged since some time,
 the encrypted messages in the Inbox may be annoying.
 
-If so, you should switch to a dedicated chat profile as follows:
+If so, you should change the profile as follows:
 
 1. Open Delta Chat, go to **Settings → Advanced → Relays**
 

--- a/legacy-move.html
+++ b/legacy-move.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<meta http-equiv="refresh" content="0; url=en/legacy-move">


### PR DESCRIPTION
this PR adds a page that describes steps that should be done when a user has "Move to DeltaChat folder" enabled

the page should not be linked from anywhere but from the device message added  at https://github.com/chatmail/core/pull/7777

by the redirect-file, we have at least the option to translate it later, we'll see if that is worth the effort

(a similar page is needed for the "Only fetch from DeltaChat folder" option, which, however, is by far not that often used, as that was never the default and always required much more advanced user for server-side filtering)

(i was first thinking to write smth about doing the move in the classic client (it is working for me quite fine), but we should not recommend that officially, it is a call for further trouble and support effort. same if we keep one of the options in the one or other form (as discussed here and there :)