### PR TITLE
skip 'show email' part from 'disable move to delta' instructions

### DIFF
--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -52,7 +52,7 @@ If so, you should change the profile as follows:
     - **If you cannot scan,** right click or long tap the QR code,
       select "Copy Link" and paste that to the scanner window
 
-5. Tab the newly added relay so that it becomes **Default**
+5. Tap the newly added relay so that it becomes **Default**
 
 Then, continue chatting, **your contacts will learn the new relay** over time -
 until then, you are still reachable on the old email address.

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -41,23 +41,18 @@ the encrypted messages in the Inbox may be annoying.
 
 If so, you should change the profile as follows:
 
-1. Open Delta Chat, go to **Settings → Advanced**
+1. Go to **Settings → Advanced → Relays**
 
-2. If not yet the case, **disable "Only fetch from DeltaChat Folder"** and  
-   **set "Show Classic Emails" to "All"**
+2. Tap **Add Relay**
 
-3. Go to **Settings → Advanced → Relays**
+3. Go to <https://chatmail.at/relays>, and select one of the relays shown there
 
-4. Tap **Add Relay**
-
-5. Go to <https://chatmail.at/relays>, and select one of the relays shown there
-
-6. **Scan the QR code** shown on the relay's website
+4. **Scan the QR code** shown on the relay's website
 
     - **If you cannot scan,** right click or long tap the QR code,
       select "Copy Link" and paste that to the scanner window
 
-7. Tab the newly added relay so that it becomes **Default**
+5. Tab the newly added relay so that it becomes **Default**
 
 Then, continue chatting, **your contacts will learn the new relay** over time -
 until then, you are still reachable on the old email

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -41,7 +41,7 @@ the encrypted messages in the Inbox may be annoying.
 
 If so, you should change the profile as follows:
 
-1. Go to **Settings → Advanced → Relays**
+1. Open Delta Chat, go to **Settings → Advanced → Relays**
 
 2. Tap **Add Relay**
 

--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -31,11 +31,11 @@ this will happen implicitly the next weeks.
 
 ### Optional Steps
 
-If you are using the email for chatting only,
+If you are using the email address for chatting only,
 and not using another email app for that address beside Delta Chat,
 the following steps are not needed.
 
-**Only if you share the same email** for chatting and classic usage,
+**Only if you share the same email address** for chatting and classic usage,
 which is discouraged since some time,
 the encrypted messages in the Inbox may be annoying.
 
@@ -55,10 +55,10 @@ If so, you should change the profile as follows:
 5. Tab the newly added relay so that it becomes **Default**
 
 Then, continue chatting, **your contacts will learn the new relay** over time -
-until then, you are still reachable on the old email
+until then, you are still reachable on the old email address.
 
-**Some weeks later,** you can remove the old email, 
-which will then stop cluttering your classic Inbox with encrypted messages
+**Some weeks later,** you can remove the old email address, 
+which will then stop cluttering your classic Inbox with encrypted messages.
 
 
 ## Background


### PR DESCRIPTION
changing 'show email' will not be required to add relay on 1.41.0; reason is to not push users into potentially receiving spam until we have a 'show encrypted only' option

cc @link2xt 