### PR TITLE
fix: rewrite verify downloads for desktop

### DIFF
--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -20,9 +20,82 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
 
 ## Desktop
 
-You can find detailed instructions for verification at `https://download.delta.chat/desktop/v<version>/signature.asc`
+To verify the integrity and authenticity of Delta Chat Desktop downloads, follow these steps:
 
-The public key used for signing desktop releases is published below and on <https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu>.
+### Step 1: Download the Required Files
+
+Download the release file and `signature.asc` from the download directory. The `signature.asc` file contains SHA512 checksums and is cryptographically signed.
+
+### Step 2: Verify the Download
+
+The signature.asc file is signed with the following key:
+
+**Primary Key Fingerprint:**
+`63CD 1F81 5BA5 6051 8376 999C 626E 26C8 1695 1308`
+
+**Public Key:** [deltachat_certificate.asc.txt](../assets/deltachat_certificate.asc.txt)
+**Also available on:** [keys.openpgp.org](https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu)
+
+#### Using GPG:
+
+```bash
+# Import the public key from downloaded key
+gpg --import deltachat_certificate.asc.txt
+
+# OR via curl from website
+curl https://delta.chat/assets/deltachat_certificate.asc.txt | gpg --import
+
+
+# Verify signature and file integrity in one command
+gpg --decrypt signature.asc | shasum -a 512 --ignore-missing -c -
+```
+
+--ignore-missing is only added to supress warnings for not downloaded files that have a checksum in the list
+
+**Expected output:**
+```
+gpg: Good signature from "deltachat-signing@merlinux.eu" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 63CD 1F81 5BA5 6051 8376 999C 626E 26C8 1695 1308
+<filename>: OK
+```
+
+The warning is normal - the signature is valid, but GPG warns because you haven't explicitly trusted the key. **Important:** Verify the fingerprint matches the one shown above.
+
+If you want to suppress this warning in the future (optional):
+```bash
+gpg --lsign-key deltachat-signing@merlinux.eu
+```
+
+#### If GPG is not available just check the filesums (less secure)
+
+```bash
+cat signature.asc | grep deltachat | shasum -a 512 --ignore-missing -c -
+```
+grep is needed to extract only the lines with checksums from signature.asc
+
+#### Using rsop (alternative):
+
+```bash
+cat signature.asc | rsop inline-verify deltachat_certificate.asc.txt
+```
+
+### Complete Example
+
+```bash
+# Download the files
+wget https://download.delta.chat/desktop/v2.35.0/deltachat-desktop_2.35.0_amd64.deb
+wget https://download.delta.chat/desktop/v2.35.0/signature.asc
+
+# Import key
+gpg --import deltachat_certificate.asc.txt
+
+# Verify signature and file integrity
+gpg --decrypt signature.asc | shasum -a 512 -c -
+```
+
+### Public Key Block
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
One part of resolving https://github.com/deltachat/deltachat-desktop/issues/6030

We need to adapt the signature.asc file that is generated and uploaded by desktop-builder before we can publish this.

The idea is to have the PGP key together with the sha5 checksums in one file so it can be verified in one command

```bash
gpg --decrypt signature.asc | shasum -a 512 --ignore-missing -c -
```
sha1 checksums will be removed

The file signature.asc will contain something like

```
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA512

b67e3e0fde06a1a98631a5a4a32221de879e28029542726bc8646418ba90db2b681b46130b9cb955e3b470a7a007c6d067da3a317cafc6d3d13dc28d242cf0be  DeltaChat-2.35.0-Portable.x64.exe
5a83e282dfa98908a0dadd19260405c8093dd2a3b0c451cc281f05034bc6900751b8b86cb1bfd68d5ff2f14373f31f2426213c7f615720853d509930fa4ef9b1  DeltaChat-2.35.0-Setup.x64.exe
34bebfba5d83a10a0ebb2ded889eeedd2b22f9fbf845fa23f7ef1997acb12991c2ef74a4025ed599dc38c7f52d7413fcf586e9fb90a9deebdd8f06caf504faab  DeltaChat-2.35.0-arm64.AppImage
etc.
-----BEGIN PGP SIGNATURE-----

wnUEARYKAB0WIQRjzR+BW6VgUYN2mZxibibIFpUTCAUCaUqrnAAKCRBibibIFpUT
CFWSAQDwBJc0jzOsyy/LKIFpiq1kPz9GwBttHA9QTotaz0qT3gEAwFTHuwdLQo7e
AvoE4W7qEwqKvzRSYYwWJ8Unadg2lQ8=
=M80U
-----END PGP SIGNATURE-----
```