### PR TITLE
improve desktop download verification

### DIFF
--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -28,7 +28,7 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
    `<VERSION>` needs to be replaced by the version number, eg. `2.33.0`
 
    ```
-   wget https://download.delta.chat/desktop/v<VERSION>/signature.asc
+   wget https://download.delta.chat/desktop/v<VERSION>/signed-checksums.txt
    wget https://delta.chat/assets/deltachat_certificate.asc.txt
    gpg --import deltachat_certificate.asc.txt
    ```
@@ -38,7 +38,7 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
 3. **Verify and check results**
 
    ```
-   gpg --decrypt signature.asc | shasum -a 512 --ignore-missing -c -
+   gpg --decrypt signed-checksums.txt | shasum -a 512 --ignore-missing -c -
    ```
 
    Expected output:
@@ -55,6 +55,6 @@ To print the SHA256 fingerprints of the APK signing certificate you can use eg.
    The warning is normal as you have not explicitly trusted the key.
 
 If gpg is broken on your system, you can use  
-`cat signature.asc | rsop inline-verify deltachat_certificate.asc.txt` or  
-`cat signature.asc | grep deltachat | shasum -a 512 --ignore-missing -c -` -
+`cat signed-checksums.txt | rsop inline-verify deltachat_certificate.asc.txt` or  
+`cat signed-checksums.txt | grep deltachat | shasum -a 512 --ignore-missing -c -` -
 note, that the latter checks integrity but _not_ the developer's key.

--- a/en/verify-downloads.md
+++ b/en/verify-downloads.md
@@ -18,26 +18,43 @@ For Android, you can verify the signing certificate on the APK matches one of th
 To print the SHA256 fingerprints of the APK signing certificate you can use eg.  
 `keytool -printcert -jarfile <APK-file>`
 
+
 ## Desktop
 
-You can find detailed instructions for verification at `https://download.delta.chat/desktop/v<version>/signature.asc`
+1. Open your terminal and **change directory** to the file you want to verify, eg.  
+   `deltachat-desktop_<VERSION>_amd64.deb`
 
-The public key used for signing desktop releases is published below and on <https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu>.
+2. **Download signed checksums and import key;**
+   `<VERSION>` needs to be replaced by the version number, eg. `2.33.0`
 
-```
------BEGIN PGP PUBLIC KEY BLOCK-----
+   ```
+   wget https://download.delta.chat/desktop/v<VERSION>/signature.asc
+   wget https://delta.chat/assets/deltachat_certificate.asc.txt
+   gpg --import deltachat_certificate.asc.txt
+   ```
 
-xjMEaDSKLBYJKwYBBAHaRw8BAQdAbpU7t0wU34c3csvF60TBF+8NoH+xxew6vpG4
-zjHdSlrNHWRlbHRhY2hhdC1zaWduaW5nQG1lcmxpbnV4LmV1wo8EEBYIADcCGQEF
-Amg0iiwCGwMICwkIBwoNDAsFFQoJCAsCFgIBJxYhBGPNH4FbpWBRg3aZnGJuJsgW
-lRMIAAoJEGJuJsgWlRMIQPoBAMjOBiayYuO2Eukfk1nC05sAOWeuEHuPnFugagMN
-4ZjQAQCTS+YU83ydgv38sK6P5DykrrOaJRpxCA8K4xeRAPwlAM44BGg0iiwSCisG
-AQQBl1UBBQEBB0Au68F0n/3QcRDzr2C3NYba3kCow4HkT/KnQs0YatVGdgMBCAfC
-eAQYFggAIAUCaDSKLAIbDBYhBGPNH4FbpWBRg3aZnGJuJsgWlRMIAAoJEGJuJsgW
-lRMIMYAA/3DQ+rGyobJzQjLcXgG3ZZoUe/WqIFZi2kIvG1k4h9uaAP9IwEKD/BmE
-nHM0/o16fERF1PNx1mqPhUsXYQmUFPmeCg==
-=isjO
------END PGP PUBLIC KEY BLOCK-----
-```
+   The key is also available at [keys.openpgp.org](https://keys.openpgp.org/search?q=deltachat-signing@merlinux.eu)
 
-Download: [deltachat_certificate.asc.txt](../assets/deltachat_certificate.asc.txt)
+3. **Verify and check results**
+
+   ```
+   gpg --decrypt signature.asc | shasum -a 512 --ignore-missing -c -
+   ```
+
+   Expected output:
+
+   ```
+   gpg: Good signature from "deltachat-signing@merlinux.eu" [unknown]
+   gpg: WARNING: This key is not certified with a trusted signature!
+   gpg:          There is no indication that the signature belongs to the owner.
+   Primary key fingerprint: 63CD 1F81 5BA5 6051 8376 999C 626E 26C8 1695 1308
+   <FILE>: OK
+   ```
+
+   Make sure the fingerprint matches and that the file you want to verify is listed.
+   The warning is normal as you have not explicitly trusted the key.
+
+If gpg is broken on your system, you can use  
+`cat signature.asc | rsop inline-verify deltachat_certificate.asc.txt` or  
+`cat signature.asc | grep deltachat | shasum -a 512 --ignore-missing -c -` -
+note, that the latter checks integrity but _not_ the developer's key.


### PR DESCRIPTION
this PR was created after trying to read and understand https://github.com/deltachat/deltachat-pages/pull/1262 , and comes with the following improvements:

- simple 1-2-3 steps, for ppl just want to get the verification done
- keep things together
- much shorter
- less "if" and "maybe" and distracting alternatives
- explain what the disadvantage is of not using gpg/rsop
- troubleshooting at the end
- visually less cluttered, matching appearance of the page elsewhere

in general, i did not check if the used method is "best practise", but sorted it only.

some things out of scope of this PR, but maybe can be targeted later

- i think, the name of `signature.asc` is wrong. it is no signature. it is a file listing checksums that is signed, i was a bit confused by that, `checksums.txt` would also make the whole flow much better to understand.

- it is unfortunate, that in the filenames and paths, the version is sometimes prefixed by `v` , sometimes not.

- why is the extension party `.asc.txt`? - in pgp-land, usually, it is only `.asc`

- the instructions inside `signature.asc` can be removed, they only will get outdated and broken

targets https://github.com/deltachat/deltachat-pages/pull/1262#issue-3936408354