### PR TITLE
fix: key on openpgp should binary-wise the same as here

### DIFF
--- a/assets/deltachat_certificate.asc.txt
+++ b/assets/deltachat_certificate.asc.txt
@@ -1,4 +1,6 @@
 -----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: 63CD 1F81 5BA5 6051 8376  999C 626E 26C8 1695 1308
+Comment: deltachat-signing@merlinux.eu
 
 xjMEaDSKLBYJKwYBBAHaRw8BAQdAbpU7t0wU34c3csvF60TBF+8NoH+xxew6vpG4
 zjHdSlrNHWRlbHRhY2hhdC1zaWduaW5nQG1lcmxpbnV4LmV1wo8EEBYIADcCGQEF


### PR DESCRIPTION
i tried a simple `cmp` and that failed.
sure, only because of the comments,
but one has to investigate deeper to check that
and at a first glance it looks bad.

unless there is a good reason, the files should be identical.

i would not care about removing the comments alltogether, however, changing the file on out site is easier - and maybe also makes sense to leave the "official" key untouched

<img width="1387" height="324" alt="Screenshot 2026-02-23 at 13 39 36" src="https://github.com/user-attachments/assets/f2e4ddf1-161f-4f80-981c-e70bb012cedd" />
