### PR TITLE
docs: restructure and rewrite legacy-move.md

### DIFF
--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -4,83 +4,80 @@ lang: en
 ---
 
 
-## Use a Dedicated Chat Profile
-
-> This page is a service for users still using legacy options.
+> This page is for users who share their chat address with a classic email app or webmail provider.
 >
-> If you did not get a warning,
-> go for something else, [maybe play a game inside Delta Chat](help#webxdc) :)
+> If you didn't receive a warning leading you here, feel free to ignore this page and [maybe play a game](help#webxdc). :)
 
 
-### Required Steps
+## Upcoming Change: March 2026
 
-The option "Move automatically to DeltaChat Folder"
-as well as other legacy options
-will be removed in the next weeks.
+In **March 2026**, the option **"Move automatically to DeltaChat Folder"** will be removed.
+If you are not using other email apps to read your normal inbox, this change will likely not affect you.
 
-To see how the change affects you,
-**already today**, do the following steps:
+Otherwise, encrypted chat messages may appear in your other email apps.
+To prevent this, we recommend using two separate profiles within Delta Chat:
+1.  **A Dedicated Chat Profile**: For seamless chatting with your existing contacts.
+2.  **A Classic Email Profile (Optional)**: To read your normal inbox and communicate with non-chat contacts.
 
-1. Open Delta Chat, go to **Settings → Advanced**
+With this setup, none of your contacts need to change anything.
+Your encrypted chat contacts will simply continue chatting, and you can still read and reply to emails from Delta Chat.
+Here are the two steps we recommend to take.
 
-2. **Disable "Move automatically to DeltaChat Folder"**
+### Step 1: Move towards Dedicated Chat Profile
 
-If you do not do this explicitly today,
-this will happen implicitly the next weeks.
+1.  **Add a relay**: Go to **Settings → Advanced → Relays** and tap **Add Relay**.
 
+2.  **Scan a new QR code**: Visit <https://chatmail.at/relays>, select any relay, and scan its QR code.
 
-### Optional Steps
+3.  **Set as default**: Tap the new relay and select **Default**.
 
-If you are using the email address for chatting only,
-and not using another email app for that address beside Delta Chat,
-the following steps are not needed.
+Your contacts will automatically learn your new dedicated address when they see your messages, reactions, or read receipts.
 
-**Only if you share the same email address** for chatting and classic usage,
-which is discouraged since some time,
-the encrypted messages in the Inbox may be annoying.
+### Step 2: Keep using Delta Chat for your classic email (Optional)
 
-If so, you should change the profile as follows:
+To continue receiving normal emails on your old address:
 
-1. Open Delta Chat, go to **Settings → Advanced → Relays**
+- **Mobile**: Tap your avatar and select **Add Profile**.
 
-2. Tap **Add Relay**
+- **Desktop**: Click the **"+"** button in the sidebar.
 
-3. Go to <https://chatmail.at/relays>, and select one of the relays shown there
-
-4. **Scan the QR code** shown on the relay's website
-
-    - **If you cannot scan,** right click or long tap the QR code,
-      select "Copy Link" and paste that to the scanner window
-
-5. Tap the newly added relay so that it becomes **Default**
-
-Then, continue chatting, **your contacts will learn the new relay** over time -
-until then, you are still reachable on the old email address.
-
-**Some weeks later,** you can remove the old email address, 
-which will then stop cluttering your classic Inbox with encrypted messages.
+Continue with **Create Profile** → **Use other server** → **Use classic email as relay**
+and enter your email address and password.
+After successful configuration, you will receive email messages again
+and can send replies to your email contacts just like today.
 
 
-## Background
+### Step 3: Remove the old shared address from your dedicated chat profile
 
-We want Delta Chat users to have a easy, reliable and secure messenger experience.
+After your contacts have learned about your new dedicated chat address,
+you can remove the old shared address from the "relay" list in the **Advanced Settings**.
 
-Using the same email addresses in Delta Chat and in classic email apps was the default in the early years,
-however, turned out to stand in the way of these goals.
-E.g. notifications could not be made reliable, onboarding was complex,
-encrypted messages are annoying in the inbox - and plaintext are not what we want to have in Delta Chat by default.
 
-Also, while we keep on using email technically,
-this is nothing the average user should care about -
-similar to other messenger using https under the hood.
+## Test the Change Today
 
-Therefore, by default, user get a dedicated, exclusive profile since quite some time
-and there is no need to enter an email address - let alone a phone number.
+You can see the effect of the upcoming removal now:
 
-**Since then, the onboarding is one of the easiest around - you only need to enter a name 🎉**
+1.  Go to **Settings → Advanced**.
+2.  Disable **"Move automatically to DeltaChat Folder"**.
 
-Finally removing the legacy options is the next logical step -
-it makes the app clearer and easier to support,
-freeing up developer mind space to to much more impactful things -
-as multi relay, channels and calls.
-And, of course fixing bugs, making Delta Chat a truely stable experience
+If encrypted messages start appearing in your other email apps, follow the split recommendation above.
+
+
+## Background: Shared vs. Dedicated Addresses
+
+Sharing one email address between Delta Chat and classic email apps causes several issues:
+
+- **Notifications**: You might get double notifications or none at all.
+
+- **Clutter**: Encrypted chat messages can clutter your classic email inbox.
+
+- **Complexity**: It hinders the development of major features like multi-server support.
+
+We recognize that several people who started using Delta Chat in 2024 
+or earlier appreciated using a single mailbox for "everything."
+The hundred thousand(s) of new Delta Chat users in 2025 and 2026 
+rarely know that they are using email addresses. 
+Instead of continuing to invest developer hours into what is now an edge case, 
+we are focusing on providing a seamless, reliable, and secure experience 
+while addressing the many feature requests we receive (on average 30 requests per month).
+


### PR DESCRIPTION
Shift from "Legacy" to "Dedicated vs. Shared": The term "legacy" has been removed in favor of describing the technical state: Shared addresses (shared with classic email clients) vs. Dedicated chat addresses. This is more descriptive and avoids the stigmatizing "legacy" label while accurately reflecting the technical evolution of the project.

Seamless Transition: Instead of suggesting users simply "stop" using their old address, the guide now provides a clear path to a split setup. Two Profiles, One App: Instructions are provided to create a dedicated chat profilewhile keeping the original email address as a separate, second profile for classic email usage. This ensures a "best of both worlds" experience: reliable, clutter-free chatting and full classic email access. While making the lifes for developers easier, and easing the introduction of other requested or desired features. 

