### PR TITLE
Update required Ubuntu Touch version

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -189,7 +189,7 @@
             </div>
             <div class="descr">
                 {%if tx.download.minimum != ""%}{{ tx.download.minimum }}{%else%}{{ txEn.download.minimum }}{%endif%}:
-                Ubuntu Touch 16.04
+                Ubuntu Touch 20.04
             </div>
             <div class="descr">
                 See <a href="https://delta.chat/en/2023-07-02-deltatouch">blog</a> for details about this community driven effort<br />


### PR DESCRIPTION
Officially, DeltaTouch does not support Ubuntu Touch 16.04 anymore. From time to time, releases are still backported to UT 16.04, but the store does not accept uploads for this UT version anymore, so they are available from https://codeberg.org/lk108/deltatouch/releases only.