### PR TITLE
Use `contentinfo` ARIA role for footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,7 +76,7 @@
 
 </div>
 
-<div id="footer">
+<footer>
 <p>
     <a href="references">{%if tx.references != ""%}{{ tx.references }}{%else%}{{ txEn.references }}{%endif%}</a>
     | <a href="https://github.com/deltachat/">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>
@@ -93,7 +93,7 @@
 <br>
 © 2026 Delta Chat contributors <!-- when bumping year, bump also .well-known/security.txt -->
 </p>
-</div>
+</footer>
 
 </body>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -58,14 +58,14 @@ body {
 	}
 }
 
-#footer {
+footer {
     margin: 1.5em 0 2.5em 0;
     border-top: 1px solid #BBB;
     padding: 1em;
     color: #757575;
     text-align: center;
 }
-#footer a, #footer a:visited {
+footer a, footer a:visited {
     color: #757575;
 }
 #languages {
@@ -128,7 +128,7 @@ body {
         min-width: 580px;
         max-width: 800px;
     }
-    #footer {
+    footer {
         padding: 2em;
     }	
     #languages {
@@ -274,7 +274,7 @@ sup[role="doc-noteref"]:after {
 
 
 @media print {
-    #menu, #footer, #load-comment, #comments-hint, .deltachat-banner {
+    #menu, footer, #load-comment, #comments-hint, .deltachat-banner {
         display: none !important;
     }
 }


### PR DESCRIPTION
The accessibility tree of the homepage currently identifies all major landmarks as `generic`, giving no structural indication to the page. As a first step to giving semantic, accessible structure to the page, we can change the landmark ARIA role of the footer from `generic` to `contentinfo`. By using `<footer>` directly, [we get this accessibility information for free](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/footer#technical_summary).

Depending on the appetite for this change, I can create follow-up PRs to similarly improve the remaining major landmarks via the usage of semantic tags.