### PR TITLE
Use `main` ARIA role for main content

### DIFF
--- a/39c3.html
+++ b/39c3.html
@@ -110,7 +110,7 @@
         padding-inline: 0.4em;
         padding-bottom: 0.4em;
       }
-      #content {
+      main {
         max-width: 800px;
         margin-left: auto;
         margin-right: auto;
@@ -166,7 +166,7 @@
   </head>
 
   <body>
-  <div id="content">
+  <main>
     <h2>Delta Chat @ 39c3</h2>
     <div style="display: flex; align-items: center">
       <img
@@ -320,6 +320,6 @@ So come as you are, and join <a href="https://i.delta.chat/#AB68F428FCEF88D32B46
     and let us help you if you have any issues with the installation, want
     stickers or just want to talk with us.
     <br />
-  </div>
+  </main>
   </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -17,7 +17,7 @@
 </ul>
 </div>
 
-<div id="content">
+<main>
 
 <h1>Error 404 - page not found</h1>
 
@@ -29,7 +29,7 @@ Sorry, the requested pages does not or no longer exist.
 <a href="https://delta.chat">Back to the home page</a>
 </p>
 
-</div>
+</main>
 
 </body>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
 </ul>
 </div>
 
-<div id="content">
+<main>
 
 
 {% if page.is_post == true %}
@@ -74,7 +74,7 @@
 {% endif %}
 {% endif %}
 
-</div>
+</main>
 
 <footer>
 <p>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -39,18 +39,18 @@ body {
 }
 
 
-#content {
+main {
     padding: 0em 1em 0.5em 1em;	
 }	
 
-#content p img {
+main p img {
     max-width: 100% !important;
     max-height: 600px; /*avoid portrait smartphone screenshots becoming too big*/
     height: auto;
 }
 
 @media only screen and (max-width: 640px) {
-	#content p img, iframe {
+	main p img, iframe {
 	    float: none !important;
 	}
 	.post-box {
@@ -122,7 +122,7 @@ footer a, footer a:visited {
         margin-left: 20px;
     }
 
-    #content {	   
+    main {
         margin: 0 auto;
         width: 75%;
         min-width: 580px;
@@ -147,7 +147,7 @@ footer a, footer a:visited {
 
 
 /*space between content elements*/
-#content p, #content ul, ol, h1, h2 {
+main p, main ul, ol, h1, h2 {
     margin: 1em 0;
 }
 
@@ -178,8 +178,8 @@ body {
     font-family: Tahoma, sans-serif;
 }
 
-#content ul, ol { margin-left: 1.5em; }
-#content ul li { list-style: disc outside; margin: 0.5em 0.2em; padding-left: 0.5em; }
+main ul, ol { margin-left: 1.5em; }
+main ul li { list-style: disc outside; margin: 0.5em 0.2em; padding-left: 0.5em; }
 ol li { list-style: decimal; margin: 0.5em 0.2em; padding-left: 0.5em; }
 
 h1,h2 { font-weight: normal; font-size: 26px; letter-spacing: 1px; line-height: 1.4em; color: #000; }
@@ -212,10 +212,10 @@ pre code {
     padding: 0px;
 }
 
-#content table td, #content table th { border: 1px solid #ccc; padding: 0.2em 0.4em; }
-#content table th { background-color: #eee; font-weight: bold; }
+main table td, main table th { border: 1px solid #ccc; padding: 0.2em 0.4em; }
+main table th { background-color: #eee; font-weight: bold; }
 
-#content hr { border: 1px solid #ddd; margin: 2em 0; }
+main hr { border: 1px solid #ddd; margin: 2em 0; }
 
 
 .feed {

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -14,6 +14,6 @@
 	font-weight: bold;
 }
 
-#content h1:hover .anchor::before {
+main h1:hover .anchor::before {
 	content: unset;
 }

--- a/fosdem26.html
+++ b/fosdem26.html
@@ -40,7 +40,7 @@
       margin: 0;
     }
 
-    #content {
+    main {
       max-width: 800px;
       margin-left: auto;
       margin-right: auto;
@@ -220,7 +220,7 @@
 
 <body>
 
-  <div id="content">
+  <main>
     <h2>Delta Chat @ FOSDEM 2026</h2>
     
     <div class="invite-section">
@@ -317,7 +317,7 @@
       <p>Visit us at our booth (AW1124-01) on Saturday for stickers and tech discussion.</p>
       <p>&copy; 2026 Delta Chat Project</p>
     </footer>
-  </div>
+  </main>
 
 </body>
 

--- a/tools/create-local-help.py
+++ b/tools/create-local-help.py
@@ -107,7 +107,7 @@ def generate_file(srcdir, destdir, lang, file, add_top_links, add_pagefind):
     content = read_file(srcdir + "/" + lang + "/" + file)
 
     # remove boilerplate
-    content = re.sub(r"^.*<div id=\"content\">.*<h1>.*?</h1>.*?<ul.*?>",
+    content = re.sub(r"^.*<main>.*<h1>.*?</h1>.*?<ul.*?>",
                        "<!DOCTYPE html>\n"
                      + "<html lang=\"" + lang + "\">"
                      +   "<head>"
@@ -120,7 +120,7 @@ def generate_file(srcdir, destdir, lang, file, add_top_links, add_pagefind):
                      content,
                      flags=re.MULTILINE|re.DOTALL)
 
-    content = re.sub(r"</div>.*?</body>.*</html>.*$",
+    content = re.sub(r"</main>.*?</body>.*</html>.*$",
                          "</body>"
                      + "</html>",
                      content,


### PR DESCRIPTION
The accessibility tree of all pages currently identifies the `<div id="content">` landmark as `generic`, giving no structural indication that this is the main content of the page. By using `<main>`, [we get the correct ARIA role of `main` for the main content for free](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main#landmark).

This is a follow up to https://github.com/deltachat/deltachat-pages/pull/1274.