### PR TITLE
Use `banner` and `navigation` ARIA roles for nav bar

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,11 +11,13 @@
 
 <body id="top">
 
-<div id="menu">
+<header>
+<nav>
 <ul>
 <li></li>
 </ul>
-</div>
+</nav>
+</header>
 
 <main>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,8 @@
 
 <body id="top">
 
-<div id="menu">
+<header>
+<nav>
 <ul>
 <li aria-hidden="true"><a href="../{{page.lang}}/"><img src="../assets/logos/delta-chat.svg" width="32" height="32" style="position: relative; bottom: -3px;" /></a></li>
 <li><a href="../{{page.lang}}/">{%if tx.menu.home != ""%}{{ tx.menu.home }}{%else%}{{ txEn.menu.home }}{%endif%}</a></li>
@@ -39,7 +40,8 @@
 <li><a href="help">{%if tx.menu.help != ""%}{{ tx.menu.help }}{%else%}{{ txEn.menu.help }}{%endif%}</a></li>
 <li><a href="https://support.delta.chat">{%if tx.menu.forum != ""%}{{ tx.menu.forum }}{%else%}{{ txEn.menu.forum }}{%endif%}</a></li>
 </ul>
-</div>
+</nav>
+</header>
 
 <main>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -13,7 +13,7 @@ body {
     padding-top: 0px;
 }
 	
-#menu {
+nav {
     text-align: center;
     margin-bottom: 1em;
     padding: 8px 5px;
@@ -21,14 +21,14 @@ body {
     background-image: linear-gradient(120deg, #77888f, #364e59);
 }
 	
-#menu ul {
+nav ul {
     display: flex;
     align-items: center;
     justify-content: center;
     flex-wrap: wrap;
 }
     
-#menu li {
+nav li {
     display: inline-block;
     padding-right: 0.5em;
 
@@ -100,10 +100,10 @@ footer a, footer a:visited {
     body {
         padding-top: 0px;
     }
-    #menu {
+    nav {
         padding: 10px 0;
     }
-    #menu li {
+    nav li {
         padding-right: 1.0em;
         
         a, a:visited {
@@ -174,7 +174,7 @@ body {
     background-color: #fff;
 }
 
-#menu, h1, h2, h3, h4, h5, h6 {
+nav, h1, h2, h3, h4, h5, h6 {
     font-family: Tahoma, sans-serif;
 }
 
@@ -274,7 +274,7 @@ sup[role="doc-noteref"]:after {
 
 
 @media print {
-    #menu, footer, #load-comment, #comments-hint, .deltachat-banner {
+    header, footer, #load-comment, #comments-hint, .deltachat-banner {
         display: none !important;
     }
 }


### PR DESCRIPTION
We're adding two landmarks here to represent the nav bar, with the first one sectioning out that it's the header landmark, while the second one is sectioning out the navigation landmark. It just so happens that the header landmark purely consists of the navigation landmark at the moment, but that doesn't always have to be the case.

This is a follow up to https://github.com/deltachat/deltachat-pages/pull/1274.