### PR TITLE
Stop explicitly setting font size for website

### DIFF
--- a/37c3.html
+++ b/37c3.html
@@ -8,7 +8,6 @@
     <style>
       body {
         font-family: Verdana, Arial, Helvetica, sans-serif;
-        font-size: 15px;
         line-height: 1.4em;
         color: #000;
       }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -34,7 +34,6 @@ nav li {
 
     a, a:visited {
         color: #fff;
-        font-size: 16px;
     }
 }
 
@@ -107,7 +106,7 @@ footer a, footer a:visited {
         padding-right: 1.0em;
         
         a, a:visited {
-            font-size: 18px;
+            font-size: 1.125rem;
         }
     }
 
@@ -168,7 +167,6 @@ p.blogdate {
 
 body {
     font-family: Arial, Verdana, Helvetica, sans-serif;
-    font-size: 16px;
     line-height: 1.5em;
     color: #000;
     background-color: #fff;
@@ -182,8 +180,8 @@ main ul, ol { margin-left: 1.5em; }
 main ul li { list-style: disc outside; margin: 0.5em 0.2em; padding-left: 0.5em; }
 ol li { list-style: decimal; margin: 0.5em 0.2em; padding-left: 0.5em; }
 
-h1,h2 { font-weight: normal; font-size: 26px; letter-spacing: 1px; line-height: 1.4em; color: #000; }
-h3 { font-weight: bold; font-size: 16px; letter-spacing: 1px; color: #159957; }
+h1,h2 { font-weight: normal; font-size: 1.625rem; letter-spacing: 1px; line-height: 1.4em; color: #000; }
+h3 { font-weight: bold; letter-spacing: 1px; color: #159957; }
 h4 { font-weight: bold; letter-spacing: 1px; color: #159957; }
 
 a, a:visited {
@@ -256,7 +254,7 @@ h1,h2,h3,h4,h5,h6 {
 }
 .footnotes li {
     color: #999;
-    font-size: 12px;
+    font-size: .75rem;
 }
 .footnotes li a {
     color: #999;

--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -13,11 +13,11 @@ div.download-content {
         padding: 2px 2px 7pt 7pt;
         background-color: #eee;
         background-image: linear-gradient(120deg, #f3f3f3, #eee);
-        font-size: 12px;
+        font-size: .75rem;
     }
 
     div.box div.title {
-        font-size: 20px;
+        font-size: 1.25rem;
         margin-top: 5pt;
         margin-bottom: 8px;
         margin-right: .5em;
@@ -39,7 +39,7 @@ div.download-content {
         padding: 5px;
         margin: 3px;
         text-decoration: none;
-        font-size: 16px;
+        font-size: 1rem;
         height: 48px;
         box-sizing: border-box;
         border: 2px solid #444;
@@ -60,7 +60,7 @@ div.download-content {
 
     div.box div.buttons small {
         display: block;
-        font-size: 12px;
+        font-size: .75rem;
         font-weight:normal;
     }
 


### PR DESCRIPTION
The default font size for most browsers is 16px already, but some people (including myself) like to toggle the default font size in the browser settings. Explicitly setting the default font size to 16px in CSS overrides that preference.