### PR TITLE
Remove unused `desktoponly` and `nodesktop` classes

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -94,8 +94,6 @@ footer a, footer a:visited {
 /* rough layout: desktop second 
 *******************************************************************************/
 
-.desktoponly { display: none; }
-
 @media only screen and (min-width: 640px) {
     body {
         padding-top: 0px;
@@ -134,10 +132,6 @@ footer a, footer a:visited {
     #languages {
         margin: 1em 20vw;
     }
-
-    .nodesktop { display: none; }
-    span.desktoponly, i.desktoponly, b.desktoponly { display: inline !important; }
-    div.desktoponly, p.desktoponly { display: block !important; }
 }
 
 


### PR DESCRIPTION
The last usage of `desktoponly` was in b9dbd20b871aa915648c17d828682604aedf5fe1 and the last usage of `nodesktop` was in 55b59fcda111ed3c8545f3eeec126eebe315fb0d.