### PR TITLE
Center-align socials

### DIFF
--- a/_includes/subscribe-to-feed-links.html
+++ b/_includes/subscribe-to-feed-links.html
@@ -1,2 +1,4 @@
-<a href="../feed.xml" class="feed">RSS-Feed</a>
-<a rel="me" href="https://chaos.social/@delta" class="mastodon">Mastodon</a>
+<div class="socials">
+	<a href="../feed.xml" class="feed">RSS-Feed</a>
+	<a rel="me" href="https://chaos.social/@delta" class="mastodon">Mastodon</a>
+</div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -211,15 +211,17 @@ main table th { background-color: #eee; font-weight: bold; }
 
 main hr { border: 1px solid #ddd; margin: 2em 0; }
 
+.socials {
+    display: inline-flex;
+    gap: 12px;
+}
 
 .feed {
-  margin-left: 9px;
   padding: 0 0 0 21px;
   background: url(feed-icon.png) no-repeat 0 50%;
 }
 
 .mastodon {
-  margin-left: 9px;
   padding: 0 0 0 21px;
   background: url(mastodon-icon.png) no-repeat 0 50%;
 }


### PR DESCRIPTION
A slight visual hiccup, where the socials were all off-center by 9px.

|Before|After|
|---|---|
|<img width="372" height="68" alt="image" src="https://github.com/user-attachments/assets/f60c1398-e657-4a35-a659-9d1f49399890" />|<img width="311" height="70" alt="image" src="https://github.com/user-attachments/assets/2634e71d-0668-4968-9c5d-e836715b41b1" />|