### PR TITLE
Remove magic numbers when defining social spacing

### DIFF
--- a/_includes/subscribe-to-feed-links.html
+++ b/_includes/subscribe-to-feed-links.html
@@ -1,4 +1,10 @@
 <div class="socials">
-	<a href="../feed.xml" class="feed">RSS-Feed</a>
-	<a rel="me" href="https://chaos.social/@delta" class="mastodon">Mastodon</a>
+	<a href="../feed.xml">
+		<img src="/assets/css/feed-icon.png" alt="">
+		RSS-Feed
+	</a>
+	<a rel="me" href="https://chaos.social/@delta">
+		<img src="/assets/css/mastodon-icon.png" alt="">
+		Mastodon
+	</a>
 </div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -214,16 +214,12 @@ main hr { border: 1px solid #ddd; margin: 2em 0; }
 .socials {
     display: inline-flex;
     gap: 12px;
-}
 
-.feed {
-  padding: 0 0 0 21px;
-  background: url(feed-icon.png) no-repeat 0 50%;
-}
-
-.mastodon {
-  padding: 0 0 0 21px;
-  background: url(mastodon-icon.png) no-repeat 0 50%;
+    a {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
 }
 
 h1,h2,h3,h4,h5,h6 {


### PR DESCRIPTION
The way the spacing between the social images and their text work currently work is:

1. Social images have a fixed width of 14px.
2. We add a left padding of 21px to the text.
3. The resulting visual spacing is 21px - 14px = 7px.

This means that a change in the width of a social image would break the layout. It is also a bit convoluted to understand.

By just sticking the image in HTML and specifying a `gap`, where the `gap` aligns with the spacing we visually see, things become a lot easier to reason about. Changing the width of a social image still breaks the layout, but it does so in a less surprising way.