### PR TITLE
Scale social icons with text size

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -217,6 +217,10 @@ main hr { border: 1px solid #ddd; margin: 2em 0; }
         display: flex;
         align-items: center;
         gap: 8px;
+
+        img {
+            height: 1em;
+        }
     }
 }
 


### PR DESCRIPTION
A minor follow up to #1281, where if the font size is increased or decreased, then the social icons don't similarly scale. The below screenshots are when I bumped my browser to have a font size of 40px by default.

This is not only good for those that change their font size, but makes for better code cleanliness, as the previous implementation relied on the fact that the icons were small enough to look okay again a font of 16px. Now we're not making this assumption in the icon size any more, allowing the browser to scale the icons as needed.

|Before|After|
|---|---|
|<img width="472" height="73" alt="image" src="https://github.com/user-attachments/assets/46ef9e35-c74a-464c-b719-c6a5f18a5534" />|<img width="517" height="71" alt="image" src="https://github.com/user-attachments/assets/1c801457-0f02-4386-89d0-b1ecbe20bb8b" />|