### PR TITLE
Remove empty `<p>`s in `<footer>`

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -90,9 +90,8 @@
 {%if tx.language != ""%}{{ tx.language }}{%else%}{{ txEn.language }}{%endif%}:
 {% include footer-languages.html %}
 </p>
-<p>
 {% include subscribe-to-feed-links.html %}
-<br>
+<p>
 © 2026 Delta Chat contributors <!-- when bumping year, bump also .well-known/security.txt -->
 </p>
 </footer>


### PR DESCRIPTION
We have a couple of empty `<p>` tags which are needless. We don't see this in the source code, but when inspecting the page via developer  tools, we can see the empty `<p>` tags in the footer. By rejigging things such that the `<p>` tag only wraps text content, we can remove the empty `<p>` tags, along with a `<br>` tag.