### PR TITLE
Centre the navigation bar

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -26,11 +26,11 @@ nav ul {
     align-items: center;
     justify-content: center;
     flex-wrap: wrap;
+    gap: 0.5em;
 }
     
 nav li {
     display: inline-block;
-    padding-right: 0.5em;
 
     a, a:visited {
         color: #fff;
@@ -99,10 +99,12 @@ footer a, footer a:visited {
     }
     nav {
         padding: 10px 0;
+
+        ul {
+            gap: 1em;
+        }
     }
     nav li {
-        padding-right: 1.0em;
-        
         a, a:visited {
             font-size: 1.125rem;
         }


### PR DESCRIPTION
Because we were just adding a `padding-right` to every element, that meant that the last element also had a `padding-right` when it shouldn't have. This caused the whole navigation bar to look like it's been shifted to the left by `0.5em` or `1em`, depending on the viewport width.