### PR TITLE
Remove letter spacing in headings

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -174,9 +174,9 @@ main ul, ol { margin-left: 1.5em; }
 main ul li { list-style: disc outside; margin: 0.5em 0.2em; padding-left: 0.5em; }
 ol li { list-style: decimal; margin: 0.5em 0.2em; padding-left: 0.5em; }
 
-h1,h2 { font-weight: normal; font-size: 1.625rem; letter-spacing: 1px; line-height: 1.4em; color: #000; }
-h3 { font-weight: bold; letter-spacing: 1px; color: #159957; }
-h4 { font-weight: bold; letter-spacing: 1px; color: #159957; }
+h1,h2 { font-weight: normal; font-size: 1.625rem; line-height: 1.4em; color: #000; }
+h3 { font-weight: bold; color: #159957; }
+h4 { font-weight: bold; color: #159957; }
 
 a, a:visited {
     /*color: #0063DC;*/


### PR DESCRIPTION
This is a very subjective one, but when dropping the letter spacing, I found the titles quite a bit easier to read. I think it's common to not have letter spacing on headers, but I guess design shouldn't necessarily be driven by normalcy. I found the readability improved everywhere, but it particularly improved for the h3 headers (e.g., those on the FAQ).