### PR TITLE
Align nav bar color with desktop

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -13,8 +13,7 @@ nav {
     text-align: center;
     margin-bottom: 1em;
     padding: 8px 5px;
-    background-color: #566a73;
-    background-image: linear-gradient(120deg, #77888f, #364e59);
+    background-color: #415e6b;
 }
 	
 nav ul {


### PR DESCRIPTION
The main motivation for changing the color of the nav bar is to increase the contrast between the text and background. To figure out a more accessible color, I used the [nav bar color that's already used on the desktop app](https://github.com/deltachat/deltachat-desktop/blob/e02c455d3c9c6b67493bb45e83944b83df414f4a/packages/frontend/themes/light.scss#L9). The benefit of this is having a bit of design coherence between the website and its apps.