### PR TITLE
Make `<h3>`s and `<h4>`s black

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -164,8 +164,6 @@ main ul li { list-style: disc outside; margin: 0.5em 0.2em; padding-left: 0.5em;
 ol li { list-style: decimal; margin: 0.5em 0.2em; padding-left: 0.5em; }
 
 h1,h2 { font-weight: normal; font-size: 1.625rem; line-height: 1.4em; }
-h3 { color: #159957; }
-h4 { color: #159957; }
 
 a, a:visited {
     color: #1e6bb8;


### PR DESCRIPTION
The existing green color is inaccessible, failing since per Firefox's developer tools, it "does not meet WCAG standards for accessible text." The contrast ratio is currently 3.67, whereas it should be at least 4.5 for an AA rating (not a AAA rating though). To solve this, I just set the heading to black as that's what all the other text is set to (as well as higher level headings).

A fairly subjective comment is I find this looks a bit nicer. The usage of green is very inconsistent (it's just for the h3 and h4 headings which are visible on the occasional page). To be a bit more visually coherent (perhaps as an accent color), we'd probably want to set it on other components too/instead, like buttons. 