### PR TITLE
adapt to latest relay changes

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -610,12 +610,12 @@ you can configure relays at **Settings → Advanced → Relays**:
 - You can **add** a relay by scanning its QR code;
   [chatmail.at/relays](https://chatmail.at/relays) shows some known ones.
   If you have multiple relays, you will receive messages on all of them.
+  Contacts learn your current relays automatically when you message them.
 
 - Tap on a relay to set it as **used for sending**.
 
 - If you **remove** a relay,
-  contacts who only know this relay may not reach you until you message them again -
-  they will then learn your current relay automatically.
+  contacts who only know this relay may not reach you until you message them again.
   To stay reachable in the meantime, choose **Hide from Contacts** in the confirmation dialog
   instead of removing it right away.
 

--- a/en/help.md
+++ b/en/help.md
@@ -608,7 +608,7 @@ However, if you want to,
 you can configure relays at **Settings → Advanced → Relays**:
 
 - You can **add** a relay by scanning its QR code;
-  <https://chatmail.at/relays> shows some known ones.
+  [chatmail.at/relays](https://chatmail.at/relays) shows some known ones.
   If you have multiple relays, you will receive messages on all of them.
 
 - Tap on a relay to define the one that is **used for sending**.

--- a/en/help.md
+++ b/en/help.md
@@ -611,7 +611,7 @@ you can configure relays at **Settings → Advanced → Relays**:
   [chatmail.at/relays](https://chatmail.at/relays) shows some known ones.
   If you have multiple relays, you will receive messages on all of them.
 
-- Tap on a relay to define the one that is **used for sending**.
+- Tap on a relay to set it as **used for sending**.
 
 - If you **remove** a relay,
   contacts who only know this relay may not reach you until you message them again -

--- a/en/help.md
+++ b/en/help.md
@@ -617,7 +617,7 @@ you can configure relays at **Settings → Advanced → Relays**:
   contacts who only know this relay may not reach you until you message them again -
   they will then learn your current relay automatically.
   To stay reachable in the meantime, choose **Hide from Contacts** in the confirmation dialog
-  instead of completely removing the relay.
+  instead of removing it right away.
 
 - To **show** a hidden relay again, tap on it.
 

--- a/en/help.md
+++ b/en/help.md
@@ -618,7 +618,7 @@ you can configure relays at **Settings → Advanced → Relays**:
   they will then learn your current relay automatically.
   If in doubt, choose **Hide from Contacts** in the confirmation dialog and remove it later.
 
-- To **show** a hidden relay again, tap it.
+- To **show** a hidden relay again, tap on it.
 
 For more details and future possibilities of relays,
 you can follow discussions in the [Forum](https://support.delta.chat).

--- a/en/help.md
+++ b/en/help.md
@@ -616,7 +616,8 @@ you can configure relays at **Settings → Advanced → Relays**:
 - If you **remove** a relay,
   contacts who only know this relay may not reach you until you message them again -
   they will then learn your current relay automatically.
-  If in doubt, choose **Hide from Contacts** in the confirmation dialog and remove it later.
+  To stay reachable in the meantime, choose **Hide from Contacts** in the confirmation dialog
+  instead of completely removing the relay.
 
 - To **show** a hidden relay again, tap on it.
 

--- a/en/help.md
+++ b/en/help.md
@@ -605,18 +605,20 @@ Relays are operated by different groups and people.
 By default, after installation, a relay is **automatically set up**,
 so you do not need to care about that.
 However, if you want to,
-you can configure relays at At **Settings → Advanced → Relays**:
+you can configure relays at **Settings → Advanced → Relays**:
 
 - You can **add** a relay by scanning its QR code;
   <https://chatmail.at/relays> shows some known ones.
   If you have multiple relays, you will receive messages on all of them.
 
-- The **default** defines the one where your chat partners send future messages to.
+- Tap on a relay to define the one that is **used for sending**.
 
 - If you **remove** a relay,
-  make sure another default relay was used for a sufficient amount of time.
-  Otherwise, messages from your chat partners won't reach you.
-  If in doubt, remove later.
+  contacts who only know this relay may not reach you until you message them again -
+  they will then learn your current relay automatically.
+  If in doubt, choose **Hide from Contacts** in the confirmation dialog and remove it later.
+
+- To **show** a hidden relay again, tap it.
 
 For more details and future possibilities of relays,
 you can follow discussions in the [Forum](https://support.delta.chat).


### PR DESCRIPTION
the PR adapts the "relay paragraph" to the latest changes.

some thoughts:

- i thought about adding a hint as "do not worry when multiple relays are used, we care for not using additional traffic and deduplication" - but this tends to be too technical, and also, most user probably do not have that question. let's iterate over that if questions arise frequently

- a "for ~~2.46.0~~ 2.47.0 or newer seems superfluous", we did do that in the past only for incompatibilities with other clients. it is pretty clear that one should update if an option is missing

- i did not touch parts that does not need updates technically

- "showing" needs explanation, as by the update, relays get into that state without the user opening the "delete workflow" before. this is an issue that will fade out, but it seems still be good to describe a way