### PR TITLE
Make new imageless posts keep style of other new posts

### DIFF
--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -1,12 +1,14 @@
 {% assign index = 0 %}
 {% for post in site.posts %}
 {% assign index = index | plus:1 %}
-{% if post.image and index <= 12 %}
+{% if index <= 12 %}
 <div class="post-box">
   <a href="..{{ post.url }}">
+    {% if post.image %}
     <div class="featured-image">
       <img src="{{ post.image }}" />
     </div>
+    {% endif %}
     <h2>{{ post.title }}</h2>
   </a>
   <p>


### PR DESCRIPTION
We don't have this case at the moment, but if there's a new post without an image, we currently would show the post in the style of the old blog posts. This is visually a bit odd, as it seems misplaced (and is easy to miss among the other imaged posts).

Here's some theoretical screenshots, assuming that the image for the "Delta Chat V2: a major ..." blog post didn't have an image:

|Before|After|
|---|---|
|<img width="1196" height="1342" alt="image" src="https://github.com/user-attachments/assets/6a4aee97-3f71-48ad-81a9-85d749297343" />|<img width="1196" height="1342" alt="image" src="https://github.com/user-attachments/assets/c6f1c87c-c6e8-430c-b1a7-217c37a32a78" />|
