### PR TITLE
Simplify HTML generation logic for blog

### DIFF
--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -1,7 +1,5 @@
-{% assign index = 0 %}
-{% for post in site.posts %}
-{% assign index = index | plus:1 %}
-{% if index <= 12 %}
+{% assign new_post_count = 12 %}
+{% for post in site.posts limit:new_post_count %}
 <div class="post-box">
   <a href="..{{ post.url }}">
     {% if post.image %}
@@ -17,15 +15,13 @@
     <a href="..{{ post.url }}">Read on...</a>
   </p>
 </div>
-{% else %}
+{% endfor %}
+<h2>Older posts</h2>
+{% for post in site.posts offset:new_post_count %}
 <div>
-  {% if index == 13 %}
-  <h2>Older posts</h2>
-  {% endif %}
-  <p>
-    <em>{{ post.date | date: "%B %Y" }}</em> -
-    <a href="..{{ post.url }}">{{ post.title }}</a>
-  </p>
+	<p>
+		<em>{{ post.date | date: "%B %Y" }}</em> -
+		<a href="..{{ post.url }}">{{ post.title }}</a>
+	</p>
 </div>
-{% endif %}
 {% endfor %}


### PR DESCRIPTION
This makes the logic a bit more declarative over imperative. Namely, we're not conditionalising the showing of the `h2` any more, and the `new_post_count` variable that's replacing the `index` variable is (in spirit) a constant.