### PR TITLE
Improve a11y node semantics for blog date

### DIFF
--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -10,7 +10,7 @@
     <h2>{{ post.title }}</h2>
   </a>
   <p>
-    <em>{{ post.date | date: "%B %d, %Y" }}</em> -
+    <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %d, %Y" }}</time> -
     {{ post.excerpt | strip_html }} 
     <a href="..{{ post.url }}">Read on...</a>
   </p>
@@ -20,7 +20,7 @@
 {% for post in site.posts offset:new_post_count %}
 <div>
 	<p>
-		<em>{{ post.date | date: "%B %Y" }}</em> -
+		<time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %Y" }}</time> -
 		<a href="..{{ post.url }}">{{ post.title }}</a>
 	</p>
 </div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -176,6 +176,10 @@ a:hover {
     text-decoration: underline;	
 }
 
+time {
+    font-style: italic;
+}
+
 code, pre, blockquote { background-color: #eee; overflow-x: scroll;}
 pre, blockquote { padding: 2px 1em; }
 blockquote { font-style: italic; }


### PR DESCRIPTION
With `<em>`, the accessibility tree says that the date we're providing has an emphasis. I'm assuming we only used `<em>` as it provides italicised text by default. In this context, the date doesn't need to be emphasised semantically.

By replacing it with the more correct HTML tag of `<time>`, the accessibility tree reads this as a "time" node, which accurately describes what it is.