### PR TITLE
Use unitless numbers for `line-height` values

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -152,7 +152,7 @@ p.blogdate {
 
 body {
     font-family: Arial, Verdana, Helvetica, sans-serif;
-    line-height: 1.5em;
+    line-height: 1.5;
 }
 
 nav, h1, h2, h3, h4, h5, h6 {
@@ -163,7 +163,7 @@ main ul, ol { margin-left: 1.5em; }
 main ul li { list-style: disc outside; margin: 0.5em 0.2em; padding-left: 0.5em; }
 ol li { list-style: decimal; margin: 0.5em 0.2em; padding-left: 0.5em; }
 
-h1,h2 { font-weight: normal; font-size: 1.625rem; line-height: 1.4em; }
+h1,h2 { font-weight: normal; font-size: 1.625rem; }
 h3 { color: #159957; }
 h4 { color: #159957; }
 


### PR DESCRIPTION
Per the [advice of MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/line-height#prefer_unitless_numbers_for_line-height_values), we should "prefer unitless numbers for line-height values". The example given is quite informative, and explains why removing the `line-height` from the `h1` and `h2` causes the text to become squashed. Now we can let the headers inherit the `line-height`, causing the `line-height` to scale relative to its own font size instead of it's parents.