### PR TITLE
Align languages section width with rest of page

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -64,7 +64,7 @@ footer a, footer a:visited {
     color: #757575;
 }
 #languages {
-    margin: 1em;
+    margin-block: 1em;
 }
 
 .featured-image {
@@ -114,8 +114,9 @@ footer a, footer a:visited {
         margin-left: 20px;
     }
 
+    #languages,
     main {
-        margin: 0 auto;
+        margin-inline: auto;
         width: 75%;
         min-width: 580px;
         max-width: 800px;
@@ -123,9 +124,6 @@ footer a, footer a:visited {
     footer {
         padding: 2em;
     }	
-    #languages {
-        margin: 1em 20vw;
-    }
 }
 
 


### PR DESCRIPTION
With the status quo, when I'm on my desktop looking at the website in full screen, the footer looks a bit odd because the languages section is the widest element on the screen. When I'm on mobile, it looks a bit odd as the languages section is needlessly squashed.

With these changes, we just align the width of the languages component with the rest of the page, so it scales as expected on different viewports.