### PR TITLE
make social media paths relative again

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Same for a blog post that is not translated.
 Further Hints
 --------------------------------------------------------------------------------
 
+- the website is **mirrored to subdirectories** as <https://deltachat.github.io/deltachat-pages>,
+  therefore, wherever possible, do not use absolute paths as `/assets/smth.jpg`.
+  instead, **use relative paths** as `../assets/smth.jpg`.
+
 - wherever possible, use **Markdown** instead of HTML, 
   esp. in files for translation.
 

--- a/_includes/subscribe-to-feed-links.html
+++ b/_includes/subscribe-to-feed-links.html
@@ -1,10 +1,10 @@
 <div class="socials">
 	<a href="../feed.xml">
-		<img src="/assets/css/feed-icon.png" alt="">
+		<img src="../assets/css/feed-icon.png" alt="">
 		RSS-Feed
 	</a>
 	<a rel="me" href="https://chaos.social/@delta">
-		<img src="/assets/css/mastodon-icon.svg" alt="">
+		<img src="../assets/css/mastodon-icon.svg" alt="">
 		Mastodon
 	</a>
 </div>


### PR DESCRIPTION
they were made absolute at https://github.com/deltachat/deltachat-pages/pull/1287 - accidentally, as it was also not really visible they were relative in the css.

anyways, reason for that are mirrors as https://deltachat.github.io/deltachat-pages - for which we cannot guarantee that they are placed in the root folder of a server.

but already the "staging" preview fail with the absolute path

## before / after

<img width="303" height="110" alt="Screenshot 2026-04-10 at 14 44 33" src="https://github.com/user-attachments/assets/4064302f-7a7b-4f4a-955a-31c5facef18a" />
<img width="303" height="110" alt="Screenshot 2026-04-10 at 14 52 01" src="https://github.com/user-attachments/assets/df0f754c-beff-4457-bc97-246396284d2b" />
