### PR TITLE
Remove unused CSS ruleset

### DIFF
--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -4,10 +4,6 @@ div.download-content {
 
     margin-bottom: 2em;
 
-    div.recommendation-section div.recommendation-bg {
-        border: 1px solid red;
-    }
-
     div.box {
         margin: 1em 0pt;
         padding: 2px 2px 7pt 7pt;


### PR DESCRIPTION
The class `recommendation-bg` isn't applied anywhere, so this rule is never applied.