### PR TITLE
Simplify download recommendation display logic

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -6,9 +6,7 @@
 
 <div class="download-content">
     <h1>{%if tx.menu.download != ""%}{{ tx.menu.download }}{%else%}{{ txEn.menu.download }}{%endif%}</h1>
-    <div id="recommendation-section" hidden>
-        <div id="recommend"></div>
-    </div>
+    <div id="recommendation"></div>
     <details id="boxes" open>
         <summary id="boxes-summary" hidden>{%if tx.download.other != ""%}{{ tx.download.other }}{%else%}{{ txEn.download.other }}{%endif%}</summary>
         <div class="box" id="android">

--- a/_sass/_downloadpage.scss
+++ b/_sass/_downloadpage.scss
@@ -4,6 +4,10 @@ div.download-content {
 
     margin-bottom: 2em;
 
+    #recommendation:empty {
+        display: none;
+    }
+
     div.box {
         margin: 1em 0pt;
         padding: 2px 2px 7pt 7pt;

--- a/assets/js/download-page2.js
+++ b/assets/js/download-page2.js
@@ -1,12 +1,9 @@
 function main() {
     var os = userAgentToOS();
     if (os!=='') {
-        document.getElementById("recommendation-section").hidden = false;
         document.getElementById("boxes").removeAttribute("open");
         document.getElementById("boxes-summary").hidden = false;
-
-        var recommend = document.getElementById("recommend");
-        recommend.appendChild(document.getElementById(os));
+        document.getElementById("recommendation").appendChild(document.getElementById(os));
     }
 }
 


### PR DESCRIPTION
Removes an unnecessary DOM node, gives the DOM node a better name, and moves the display logic to CSS.