### PR TITLE
update link for alternative clients

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -14,7 +14,7 @@ The desktop versions do not require Delta Chat to be installed on a phone.
   [iOS](https://deltachat.github.io/deltachat-ios/CHANGELOG#delta-chat-ios-changelog),
   [Core](https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md)
 
-- [Alternative Clients](https://support.delta.chat/t/list-of-all-know-client-projects/3059)
+- [Alternative Clients](https://chatmail.at/clients)
 
 - [Provider Database](https://providers.delta.chat/)
 


### PR DESCRIPTION
https://support.delta.chat/t/list-of-all-know-client-projects/3059 is outdated and points to https://chatmail.at/clients