### PR TITLE
avoid keeping relay, mention hiding relays

### DIFF
--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -54,11 +54,13 @@ If so, you should change the profile as follows:
 
 5. Tap the newly added relay so that it becomes **Default**
 
-Then, continue chatting, **your contacts will learn the new relay** over time -
-until then, you are still reachable on the old email address.
+6. **Remove the old email address**
 
-**Some weeks later,** you can remove the old email address, 
-which will then stop cluttering your classic Inbox with encrypted messages.
+7. **Message your contacts;** their Delta Chat will learn the new relay automatically.
+
+In step 6. you are also offered to _hide instead of removing._
+In this case, you will continue receiving messages from the old email address,
+however, be prepared that **removing messages in Delta Chat will remove them on the email server.**
 
 
 ## Background


### PR DESCRIPTION
delay deleting relays may result in unexpectedly deleted messages, if one is not aware that deleting in Delta Chat also deletes on the email address used a a relay. 

directly removing the relay seems to be the option with less friction therefore, esp. as the user sees the message in their classic app - even if they cannot decrypt it.

ftr, it is good that we get rid of all that confusion, by stop saying one shall share an email address with eg. thunderbird and delta ...