### PR TITLE
Update desktop to 2.49.1

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -1,7 +1,7 @@
 {% assign txEn = site.data.lang['en']['en'] %}
 {% assign tx = site.data.lang[page.lang][page.lang] %}
 
-{% assign VERSION_DESKTOP = "2.49.0" %}
+{% assign VERSION_DESKTOP = "2.49.1" %}
 {% assign VERSION_ANDROID = "2.49.0" %}
 
 <div class="download-content">


### PR DESCRIPTION
2.49.0 for macOS is broken https://github.com/deltachat/deltachat-desktop/issues/6210, about time to stop distributing it.

The dir is in place, I believe that's all that's required to bump this version? https://download.delta.chat/desktop/v2.49.1/

Edit: I simply parroted https://github.com/deltachat/deltachat-pages/pull/1331 and #1315.