### PR TITLE
Remove unused `ol` styling

### DIFF
--- a/ca/gdpr-website.md
+++ b/ca/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/cs/gdpr-website.md
+++ b/cs/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/de/gdpr-website.md
+++ b/de/gdpr-website.md
@@ -254,21 +254,3 @@ Wir bedienen uns im Übrigen geeigneter technischer und organisatorischer Sicher
 Diese Datenschutzerklärung hat den Stand November 2021. Durch die Weiterentwicklung unserer Website und Angebote oder aufgrund geänderter gesetzlicher beziehungsweise behördlicher Vorgaben, kann es notwendig werden, diese Datenschutzerklärung zu ändern.
 
 Die jeweils aktuelle Datenschutzerklärung kann jederzeit unter [https://support.delta.chat/privacy](https://support.delta.chat/privacy) von dir abgerufen und ausgedruckt werden.
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-

--- a/en/gdpr-website.md
+++ b/en/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/es/gdpr-website.md
+++ b/es/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/eu/gdpr-website.md
+++ b/eu/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/fr/gdpr-website.md
+++ b/fr/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/gl/gdpr-website.md
+++ b/gl/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/id/gdpr-website.md
+++ b/id/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/it/gdpr-website.md
+++ b/it/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/nl/gdpr-website.md
+++ b/nl/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/pl/gdpr-website.md
+++ b/pl/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/pt/gdpr-website.md
+++ b/pt/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/pt_BR/gdpr-website.md
+++ b/pt_BR/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/ru/gdpr-website.md
+++ b/ru/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/sk/gdpr-website.md
+++ b/sk/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/sq/gdpr-website.md
+++ b/sq/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/tr/gdpr-website.md
+++ b/tr/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/uk/gdpr-website.md
+++ b/uk/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-

--- a/zh_CN/gdpr-website.md
+++ b/zh_CN/gdpr-website.md
@@ -242,23 +242,3 @@ We use appropriate technical and organizational security measures to protect you
 This data protection declaration is valid as of November 2021. Due to the further development of our website and offers or due to changed legal or official requirements, it may become necessary to revise this data protection declaration from time to time.
 
 You can access and print out the current data protection declaration at any time under [https://support.delta.chat/privacy](https://support.delta.chat/privacy).
-
-<style>
-ol.p {
-  counter-reset: list;
-}
-ol.p > li {
-  list-style: none;
-  position: relative;
-  text-align: justify;
-}
-ol.p > li:before {
-  content: counter(list, lower-alpha) ") ";
-  counter-increment: list;
-  position: absolute;
-  left: -1.4em;
-}
-</style>
-
-
-


### PR DESCRIPTION
These styles are only applied if the class `"p"` is also applied to the `ol`. Since https://github.com/deltachat/deltachat-pages/pull/495, no `ol`'s have had a class `"p"` attached to them, so these styles are completely unused.