### PR TITLE
Remove styles in `_normalize.scss` if always overridden by `_base.scss`

### DIFF
--- a/_sass/_normalize.scss
+++ b/_sass/_normalize.scss
@@ -13,27 +13,6 @@ html {
   -webkit-text-size-adjust: 100%; /* 2 */
 }
 
-/* Sections
-   ========================================================================== */
-
-/**
- * Remove the margin in all browsers.
- */
-
-body {
-  margin: 0;
-}
-
-/**
- * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
- */
-
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-
 /* Grouping content
    ========================================================================== */
 


### PR DESCRIPTION
At the top of our `_base.scss`, we always override these values, so setting them here is pretty useless.