### PR TITLE
ci: make environment secrets available for staging

### DIFF
--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -7,6 +7,8 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: "staging.delta.chat"
 
     # Permission to post to PR details.
     permissions:


### PR DESCRIPTION
I'm trying setup the secrets so we can individually approve workflows for outside contributors.