### PR TITLE
ci: use environment secrets for production

### DIFF
--- a/.github/workflows/jekyll-main.yml
+++ b/.github/workflows/jekyll-main.yml
@@ -19,6 +19,8 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: "production"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
To deprecate the old key, we need to:

- [x] merge this PR
- [x] deploy https://github.com/deltachat/sysadmin/pull/285
- [x] delete the repository-wide secret

Then we can think about allowing `pull_request_target` for the staging GH action.