### PR TITLE
Localize table related rules

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -2,7 +2,6 @@
 *******************************************************************************/
 
 * {margin:0;padding:0}
-table {border-collapse:collapse} th {text-align:left;}
 
 
 
@@ -192,8 +191,19 @@ pre code {
     padding: 0px;
 }
 
-main table td, main table th { border: 1px solid #ccc; padding: 0.2em 0.4em; }
-main table th { background-color: #eee; }
+table {
+    border-collapse: collapse;
+
+    td, th {
+        border: 1px solid #ccc;
+        padding: 0.2em 0.4em;
+    }
+
+    th {
+        text-align: left;
+        background-color: #eee;
+    }
+}
 
 .socials {
     display: inline-flex;


### PR DESCRIPTION
Essentially just moves the `<table>` related rules from the normalise section of the stylesheet to where other `<table>` related rules are.

Some of the `main table` selectors are now just `table`. No meaningful difference as the only `table`s that exist on the site are in a `main` anyway. IMO it was needlessly specific previously.