### PR TITLE
Fix link to Calendar online demo

### DIFF
--- a/_posts/2023-06-28-webxdc-import-export.md
+++ b/_posts/2023-06-28-webxdc-import-export.md
@@ -24,7 +24,7 @@ To showcase and design the new APIs we developed a little [cross-platform Calend
   where the recipient(s) can tap the received file 
   to import the invite into their own favorite native calendar app,
 
-- can also run unmodified as an [Calendar online demo](https://webxdc.codeberg.page/calendar/@demo/)
+- can also run unmodified as an [Calendar online demo](https://webxdc.codeberg.page/calendar/)
   which however stops short of the actual chat-sharing activity.
 
 You may [download the latest released Calendar app here](https://codeberg.org/webxdc/calendar/releases)


### PR DESCRIPTION
Updated the demo link for the Calendar online demo to the correct URL. Calendar now uses a forgejo action to publish the demo branch to https://webxdc.codeberg.page/calendar/