### PR TITLE
download: add community-maintained openSUSE build service packages

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -151,6 +151,7 @@
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code><br />
                 FreeBSD install (community maintained): <code>pkg install deltachat-desktop</code>
+                Fedora, Mageia, and openSUSE packages (community maintained): <a target="blank" href="https://software.opensuse.org/download.html?project=home%3Aoberkut&package=deltachat-desktop">Installation Instructions</a>
             </div>
             <details>
                 <summary class="noupgrades">

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -150,7 +150,7 @@
                 Arch manual install: <code>pacman -S deltachat-desktop</code><br />
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code><br />
-                FreeBSD install (community maintained): <code>pkg install deltachat-desktop</code>
+                FreeBSD install (community maintained): <code>pkg install deltachat-desktop</code><br />
                 Fedora, Mageia, and openSUSE packages (community maintained): <a target="blank" href="https://software.opensuse.org/download.html?project=home%3Aoberkut&package=deltachat-desktop">Installation Instructions</a>
             </div>
             <details>

--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -151,7 +151,7 @@
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code><br />
                 FreeBSD install (community maintained): <code>pkg install deltachat-desktop</code><br />
-                Fedora, Mageia, and openSUSE packages (community maintained): <a target="blank" href="https://software.opensuse.org/download.html?project=home%3Aoberkut&package=deltachat-desktop">Installation Instructions</a>
+                Fedora, Mageia, and openSUSE packages (community maintained): <a href="https://software.opensuse.org/download.html?project=home%3Aoberkut&package=deltachat-desktop">Installation Instructions</a>
             </div>
             <details>
                 <summary class="noupgrades">


### PR DESCRIPTION
They seem to ship timely enough, https://download.opensuse.org/repositories/home:/oberkut/16.0/x86_64/ has 2.49.1 currently, for example.