### PR TITLE
increase minimal iOS version

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -69,7 +69,7 @@
             </div>
             <div class="descr">
                 {%if tx.download.minimum != ""%}{{ tx.download.minimum }}{%else%}{{ txEn.download.minimum }}{%endif%}:
-                iOS 14, iPhone 6s, iPad 5/Air 2/Mini 4
+                iOS 15.6, iPhone 6s, iPad 5/Air 2/Mini 4
             </div>
             <div class="descr">
                 <a href="https://github.com/deltachat/deltachat-ios">{%if tx.download.source_code != ""%}{{ tx.download.source_code }}{%else%}{{ txEn.download.source_code }}{%endif%}</a>


### PR DESCRIPTION
this is needed because of the move to LiquidGlass at https://github.com/deltachat/deltachat-ios/issues/2973, postponing will probably not be an option any longer soon.

all devices that got iOS 14 get iOS 15.6 as well,
so this change do not affect the many.

however, we know about the issues that iOS version increase can cause - that is the reason we postponed as long as we could, still, we need to avoid to maintain two branches.