### PR TITLE
feat: add link to gentoo overlay

### DIFF
--- a/_includes/download-boxes.html
+++ b/_includes/download-boxes.html
@@ -151,6 +151,7 @@
                 Nix manual install: <code>nix-env -f "&lt;nixpkgs&gt;" -iA deltachat-desktop</code><br />
                 Snap manual install (community maintained): <code>sudo snap install deltachat-desktop</code><br />
                 FreeBSD install (community maintained): <code>pkg install deltachat-desktop</code><br />
+                Gentoo overlay (community maintained): <code><a href="https://git.chaotic.ninja/shinyoukai/deltachat-overlay#usage">Usage Instructions</a></code><br />
                 Fedora, Mageia, and openSUSE packages (community maintained): <a href="https://software.opensuse.org/download.html?project=home%3Aoberkut&package=deltachat-desktop">Installation Instructions</a>
             </div>
             <details>


### PR DESCRIPTION
see https://github.com/deltachat/deltachat-desktop/issues/6503

We should add that also to  https://chatmail.at/clients