### PR TITLE
ci: rrsync prepends the restricted upload path, we need to leave it out

### DIFF
--- a/.github/workflows/jekyll-main.yml
+++ b/.github/workflows/jekyll-main.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p "$HOME/.ssh"
           echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
           chmod 600 "$HOME/.ssh/key"
-          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/result/ "${{ secrets.USERNAME }}@delta.chat:/var/www/html/_site"
+          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/result/* "${{ secrets.USERNAME }}@delta.chat:"
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default

--- a/.github/workflows/jekyll-main.yml
+++ b/.github/workflows/jekyll-main.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p "$HOME/.ssh"
           echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
           chmod 600 "$HOME/.ssh/key"
-          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/result/* "${{ secrets.USERNAME }}@delta.chat:"
+          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/result/ "${{ secrets.USERNAME }}@delta.chat:"
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -43,7 +43,7 @@ jobs:
           mkdir -p "$HOME/.ssh"
           echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
           chmod 600 "$HOME/.ssh/key"
-          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/result/ "${{ secrets.USERNAME }}@delta.chat:/var/www/html/staging/${PR_ID}/"
+          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/result/ "${{ secrets.USERNAME }}@delta.chat:${PR_ID}"
         env:
           PR_ID: ${{github.event.pull_request.number}}
 


### PR DESCRIPTION
This is necessary because https://github.com/deltachat/sysadmin/issues/270 switches our server-side authentication to rrsync, and that uploads to a restricted path already; keeping it like this will result in a destination path like `/var/www/html/var/www/html`.

We need to re-run CI and merge after migrating page to www.