### PR TITLE
adapt relay removal

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -729,12 +729,7 @@ you can configure relays at **Settings → Advanced → Relays**:
 
 - Tap on a relay to set it as **used for sending**.
 
-- If you **remove** a relay,
-  contacts who only know this relay may not reach you until you message them again.
-  To stay reachable in the meantime, choose **Hide from Contacts** in the confirmation dialog
-  instead of removing it right away.
-
-- To **show** a hidden relay again, tap on it.
+- If a relay is no longer working, you can **remove** it.
 
 For more details and future possibilities of relays,
 you can follow discussions in the [Forum](https://support.delta.chat).


### PR DESCRIPTION
i was considering to write smth. about that relays are removed delayed only, but i did not find an easy enough wording, that does not confuse user more than it would help them, and would bring up a lot of follow-up discussion, so i skipped that.  we want to easy things for the user :)
also, this is subject to change, easily outdated and we're not doing that level of detail at other places for the "non-nerd user"

instead, i am referring to "no longer working" relays, where this consideration is anyway less important - and we're also doing that step to get into automation in the future. 

finally, the paragraph does not claim to have a coherent overview, but points to the forum for more details.

counterpart of https://github.com/deltachat/deltachat-android/pull/4542