### PR TITLE
[draft] add privacy notes for delta chat apps

### DIFF
--- a/en/help.md
+++ b/en/help.md
@@ -1119,7 +1119,7 @@ from most recent to older:
 Some features require certain permissions,
 e.g. you need to grant camera permission if you want to [scan an invite QR code](#howtoe2ee).
 
-See [Privacy Policy](https://delta.chat/en/gdpr#24-app-permissions) for a detailed overview.
+See [Privacy Notes](https://delta.chat/en/privacy-notes#app-permissions) for a detailed overview.
 
 
 ### Where can my friends find Delta Chat?

--- a/en/privacy-notes.md
+++ b/en/privacy-notes.md
@@ -11,6 +11,15 @@ and by default nothing is ever sent to Delta Chat developers.
 Because there is no central data collection,
 a few short notes can take the place of a lengthy privacy policy.
 
+## No Profile Directory, No Search
+
+**Delta Chat has no directory of profiles and no way to search for people.**
+There is no public discovery of any kind:
+nobody can look you up, by name, address or anything else,
+and only people you share your invite link or QR code with can contact you.
+Your name and picture are of course visible to your contacts,
+but they are stored nowhere except on your devices and theirs.
+
 ## Your Data Stays on Your Device
 
 Everything you see in Delta Chat is stored on your device, and only there:

--- a/en/privacy-notes.md
+++ b/en/privacy-notes.md
@@ -1,0 +1,154 @@
+---
+title: Privacy Notes Delta Chat Apps
+lang: en
+---
+
+# Privacy Notes for Delta Chat Apps
+
+**Delta Chat apps collect zero personal data from you.**
+You don't create an account with us, there are no ads and no tracking,
+and by default nothing is ever sent to Delta Chat developers.
+Because there is no central data collection,
+a few short notes can take the place of a lengthy privacy policy.
+
+## Your Data Stays on Your Device
+
+Everything you see in Delta Chat is stored on your device, and only there:
+
+- your chats, photos, videos, voice messages and files,
+
+- your contacts and groups,
+
+- your encryption keys and settings.
+
+Delta Chat never uploads your address book to any server,
+and developers cannot access your data, not even in encrypted form.
+When you add a second device,
+your data moves directly from one of your devices to the other.
+
+## How Messages Are Delivered
+
+When you create a profile, Delta Chat automatically connects to several
+community-run "chatmail relays" which pass messages between devices:
+
+- You get a randomly generated address;
+  no phone number, name or other personal data is asked.
+
+- All messages are end-to-end encrypted, so relays cannot read them.
+
+- Message details like subject lines, group names and group members
+  are encrypted as well;
+  relays only see random addresses, message size and a randomized date.
+
+- Relays delete messages after delivery, or after a few weeks at the latest.
+
+- Standard chatmail relays do not keep records of IP addresses.
+
+- If one relay is blocked or breaks down,
+  your messages simply travel through another one.
+
+Relays are run by different people and groups around the world,
+see the [list of public relays](https://chatmail.at/relays)
+and the [FAQ about relays](help#relays).
+
+## If You Use a Classic Email Account
+
+You can also use Delta Chat with a classic email address.
+In that case your login data is stored only on your device,
+your messages pass through your email provider,
+and the privacy policy of that provider applies.
+There, messages without end-to-end encryption are possible
+and are marked with a small email icon.
+
+## Mini Apps in Chats
+
+You can attach [mini apps](help#webxdc) to a message,
+for example games, polls or shopping lists.
+Mini apps are as private as the chat you share them in:
+
+- Mini apps cannot access the internet
+  and cannot send your data anywhere.
+
+- They can only exchange data with the members of their chat,
+  using the same end-to-end encrypted messages as everything else.
+
+- App developers cannot track you or even know that you use their app.
+
+This no-internet isolation of mini apps has been
+[independently security audited](2023-05-22-webxdc-security).
+
+## Audio and Video Calls
+
+Audio and video calls are end-to-end encrypted,
+and only contacts you accepted can ring you.
+For best quality, calls connect your device
+directly to the device of your contact;
+as with any direct connection,
+the devices [see each other's IP address](help#who-sees-my-ip-address)
+during the call.
+
+## Message Notifications
+
+To show new messages while the app is not running,
+Delta Chat uses the "push service" of your platform,
+a server that wakes up apps on your device.
+Push services are run by Apple for iPhones, by Google for Android phones,
+by the Ubuntu Touch community, or follow the open Web Push standard.
+
+- Your device creates an anonymous "wake-up token"
+  whose only purpose is to tell your phone to check for new messages.
+
+- Push services never see message content or names,
+  and do not learn who you are or what you write.
+
+- The small Delta Chat forwarding service in between
+  forgets each token within moments and stores nothing about you.
+
+- If you turn notifications off, no token is created at all.
+
+- F-Droid and desktop versions do not use push services at all.
+
+You can find the [technical details in the FAQ](help#privacy-notifications).
+
+## Optional Statistics on Android
+
+Delta Chat for Android asks whether you want to support development
+by sending [anonymous weekly usage statistics](help#statssending),
+for example which features are used and which errors occur.
+Nothing is sent unless you agree,
+the statistics contain nothing that could identify you,
+and you can change your choice anytime at **Settings → Advanced**.
+
+## App Permissions
+
+Delta Chat only uses device permissions for things you do yourself:
+
+- **Camera** to take photos or scan an invite QR code,
+
+- **Microphone** to record voice messages or have calls,
+
+- **Location** only if you choose to share it in a chat,
+
+- **Storage** to attach or save files.
+
+Everything is processed on your device and never sent to developers.
+Internet access is the only required permission,
+as it is needed to deliver your messages.
+
+## Downloading the App
+
+When you download Delta Chat from an app store
+like Google Play or the Apple App Store,
+the store handles the download under its own privacy policy.
+Downloads from F-Droid or [get.delta.chat](https://get.delta.chat)
+require no account at all.
+
+## Questions & Contact
+
+If you have questions about these privacy notes, you can reach us:
+
+merlinux GmbH<br />
+Reichsgrafen Str. 20, 79102 Freiburg, Germany<br />
+[delta-privacy@merlinux.eu](mailto:delta-privacy@merlinux.eu)
+
+These Privacy Notes are valid as of July 2026.

--- a/en/privacy-notes.md
+++ b/en/privacy-notes.md
@@ -119,10 +119,8 @@ by the Ubuntu Touch community, or follow the open Web Push standard.
 - Push services never see message content or names,
   and do not learn who you are or what you write.
 
-- The small Delta Chat forwarding service in between
-  forgets each token within moments and stores nothing about you.
-
-- If you turn notifications off, no token is created at all.
+- The small Delta Chat token forwarding service in between
+  forgets each token within moments and knows nothing about you.
 
 - F-Droid and desktop versions do not use push services at all.
 

--- a/en/privacy-notes.md
+++ b/en/privacy-notes.md
@@ -36,8 +36,7 @@ community-run "chatmail relays" which pass messages between devices:
 
 - All messages are end-to-end encrypted, so relays cannot read them.
 
-- Message details like subject lines, group names and group members
-  are encrypted as well;
+- Message details, group names and group members are encrypted as well;
   relays only see random addresses, message size and a randomized date.
 
 - Relays delete messages after delivery, or after a few weeks at the latest.
@@ -51,14 +50,16 @@ Relays are run by different people and groups around the world,
 see the [list of public relays](https://chatmail.at/relays)
 and the [FAQ about relays](help#relays).
 
-## If You Use a Classic Email Account
+## If You Disable Forced Encryption
 
-You can also use Delta Chat with a classic email address.
-In that case your login data is stored only on your device,
-your messages pass through your email provider,
-and the privacy policy of that provider applies.
-There, messages without end-to-end encryption are possible
+By default, Delta Chat requires end-to-end encryption for all messages.
+If you instead connect a classic email account,
+or a relay that does not enforce encryption,
+messages without end-to-end encryption become possible
 and are marked with a small email icon.
+Your login data is still stored only on your device,
+but your messages pass through the servers of your chosen provider,
+whose privacy practices you need to check yourself.
 
 ## Mini Apps in Chats
 
@@ -73,6 +74,11 @@ Mini apps are as private as the chat you share them in:
   using the same end-to-end encrypted messages as everything else.
 
 - App developers cannot track you or even know that you use their app.
+
+- For fast interactions like multiplayer games,
+  mini apps can use direct connections between the devices in a chat;
+  as with [calls](#audio-and-video-calls),
+  the devices then see each other's IP address.
 
 This no-internet isolation of mini apps has been
 [independently security audited](2023-05-22-webxdc-security).

--- a/en/privacy-notes.md
+++ b/en/privacy-notes.md
@@ -5,7 +5,8 @@ lang: en
 
 # Privacy Notes for Delta Chat Apps
 
-**Delta Chat apps collect zero personal data from you.**
+**Neither the Delta Chat apps nor their developers
+collect any personal data from you.**
 You don't create an account with us, there are no ads and no tracking,
 and by default nothing is ever sent to Delta Chat developers.
 Because there is no central data collection,
@@ -13,8 +14,10 @@ a few short notes can take the place of a lengthy privacy policy.
 
 ## No Profile Directory, No Search
 
-**Delta Chat has no directory of profiles and no way to search for people.**
-There is no public discovery of any kind:
+**There is no directory of Delta Chat profiles
+and no way to search for people.**
+Profiles are not registered or indexed anywhere,
+so there is no public discovery of any kind:
 nobody can look you up, by name, address or anything else,
 and only people you share your invite link or QR code with can contact you.
 Your name and picture are of course visible to your contacts,
@@ -30,7 +33,7 @@ Everything you see in Delta Chat is stored on your device, and only there:
 
 - your encryption keys and settings.
 
-Delta Chat never uploads your address book to any server,
+The app never uploads your address book to any server,
 and developers cannot access your data, not even in encrypted form.
 When you add a second device,
 your data moves directly from one of your devices to the other.


### PR DESCRIPTION
Add en/privacy-notes.md, a short plain-language privacy document reflecting chatmail relays, zero-metadata transport, mini apps, calls and push notifications.
Point the FAQ permissions link to the new page.