### PR TITLE
Don't suggest hiding relays in legacy-move.md anymore

### DIFF
--- a/en/legacy-move.md
+++ b/en/legacy-move.md
@@ -58,10 +58,6 @@ If so, you should change the profile as follows:
 
 7. **Message your contacts;** their Delta Chat will learn the new relay automatically.
 
-In step 6. you are also offered to _hide instead of removing._
-In this case, you will continue receiving messages from the old email address,
-however, be prepared that **removing messages in Delta Chat will remove them on the email server.**
-
 
 ## Background
 


### PR DESCRIPTION
Hiding a relay is not offered anymore, so the corresponding text in `legacy-move.md` should be adapted.

The changes in this PR currently just remove the respective section, but maybe it should be kept and updated to say that hiding is offered for versions <= 2.53.0 (?) only, and later versions will take care of it automatically?