### PR TITLE
ci: update checkout action

### DIFF
--- a/.github/workflows/jekyll-main.yml
+++ b/.github/workflows/jekyll-main.yml
@@ -23,7 +23,7 @@ jobs:
       name: "production"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -26,10 +26,11 @@ jobs:
       statuses: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          allow-unsafe-pr-checkout: true
       - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
       - run: |
           echo "baseurl: /${PR_ID}" >> _config.yml


### PR DESCRIPTION
The allow-unsafe-pr-checkout input was introduced in https://github.com/actions/checkout/pull/2454, which is fine, because since https://github.com/deltachat/deltachat-pages/pull/1358, such a PR needs to be approved manually anyway.