### PR TITLE
Fix Persian footer label and include fa in local help

### DIFF
--- a/_includes/footer-languages.html
+++ b/_includes/footer-languages.html
@@ -18,4 +18,4 @@
 · <a href="../ru/">Pусский</a>
 · <a href="../uk/">Українська</a>
 · <a href="../zh_CN/">简体中文</a>
-· <a href="../fa/" dir="rtl">الفارسية</a>
+· <a href="../fa/" dir="rtl">فارسی</a>

--- a/fa/index.md
+++ b/fa/index.md
@@ -11,7 +11,7 @@ lang: fa
 
 🥳 [مینی برنامه‌های تعاملی تحت وب](https://webxdc.org/) در چت برای بازی کردن و همکاری
 
-🔒[رمزنگاری سراسری بررسی شده از لحاظ فنی](help#security-audits) که در مقابل حمله‌های شبکه و کارساز امن است.
+🔒 [رمزنگاری سراسری بررسی شده از لحاظ فنی](help#security-audits) که در مقابل حمله‌های شبکه و کارساز امن است.
 
 👈 نرم‌افزار [آزاد](https://fa.wikipedia.org/wiki/نرم‌افزار_آزاد) و [متن‌باز](https://fa.wikipedia.org/wiki/نرم‌افزار_متن‌باز) که بر روی [استاندارد‌های اینترنت](https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md) ساخته شده تا از [xkcd927](https://xkcd.com/927/) جلوگیری کند :)
 

--- a/tools/create-local-help.py
+++ b/tools/create-local-help.py
@@ -203,7 +203,7 @@ def generate_help(srcdir, destdir, add_top_links, add_pagefind):
         print("copy " + srcfile + " to " + destfile)
         copyfile(srcfile, destfile)
 
-    languages = ["cs", "de", "en", "es", "eu", "fr", "id", "it", "pl", "pt", "nl", "ru", "sk", "sq", "uk", "zh_CN"]
+    languages = ["cs", "de", "en", "es", "eu", "fa", "fr", "id", "it", "pl", "pt", "nl", "ru", "sk", "sq", "uk", "zh_CN"]
     for lang in languages:
         generate_lang(srcdir, destdir, lang, add_top_links, add_pagefind)
 


### PR DESCRIPTION
Small follow-up after #1398 / https://delta.chat/fa

### Changes
- Footer language label: Arabic «الفارسية» → Persian «فارسی»
- Add `fa` to `tools/create-local-help.py` so offline/in-app help can include Persian
- Add missing space after the lock emoji on the Persian homepage (also pushed to Transifex)

### Notes
- `redirect.js` already includes `fa` on current `main`
- Kept the existing `dir="rtl"` on the footer link
- Tiny, reviewable PR per the “less complexity” guidance in #1393