### PR TITLE
fix indentation of lists in rtl-mode by using browser defaults

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,12 +1,11 @@
-/* reset
-*******************************************************************************/
-
-* {margin:0;padding:0}
-
-
 
 /* rough layout: mobile first 
 *******************************************************************************/
+
+body, nav ul, nav ul li {
+    margin: 0;
+    padding: 0;
+}
 
 nav {
     text-align: center;
@@ -156,10 +155,6 @@ nav, h1, h2, h3, h4, h5, h6 {
     font-family: Tahoma, sans-serif;
 }
 
-main ul, ol { margin-left: 1.5em; }
-main ul li { margin: 0.5em 0.2em; padding-left: 0.5em; }
-ol li { margin: 0.5em 0.2em; padding-left: 0.5em; }
-
 h1,h2 { font-weight: normal; font-size: 1.625rem; }
 h3 { color: #159957; }
 h4 { color: #159957; }
@@ -178,7 +173,7 @@ time {
 }
 
 code, pre, blockquote { background-color: #eee; overflow-x: scroll;}
-pre, blockquote { padding: 2px 1em; }
+pre, blockquote { margin: 0; padding: 2px 1em; }
 blockquote { font-style: italic; }
 
 code {


### PR DESCRIPTION
problem is that the indentation of lists is broken for rtl texts.

reasons is that we overwrite all browser default margins and then add our owns using `-left` - this fails for rtl languages.

instead of adding additional rules for rtl, this PR removes overwriting all browser defaults.

the lists are a bit more condensed esp. on the help pages, but that's totally fine, one can regard this even as an improvement.

reviewers: esp. check the english/non-rtl homepage if there are regressions.

successor of https://github.com/deltachat/deltachat-pages/pull/1398

## before / after

<img width="380" src="https://github.com/user-attachments/assets/04a5616e-f8a6-4f83-a7c5-13c63d2df64a" /> <img width="380" src="https://github.com/user-attachments/assets/72025820-9ff6-4436-8fab-87fe4613906a" />

