### PR TITLE
remove cosmos.delta.chat footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,6 @@
 <link rel="alternate" href="https://delta.chat/feed.xml" type="application/atom+xml" title="{%if tx.rss_news_title != ""%}{{ tx.rss_news_title }}{%else%}{{ txEn.rss_news_title }}{%endif%}" />
 <link rel="apple-touch-icon" href="../assets/logos/apple-touch-icon.png" />
 <script defer src="../libresilient.js"></script>
-<script defer src="https://cosmos.delta.chat/banner.js"></script>
 </head>
 
 <body id="top">


### PR DESCRIPTION
cosmos.delta.chat serves as an overview for devs and nerds about pages related to delta chat, and can stay as that.

however, a permanent footer is over the top meanwhile,
as the page addresses more and more non-nerds.
also, the linked pages partly also stopped using the footer or a little outdated.

by the removal, more weight is given to the main menu, which is more important for most user