### PR TITLE
Sync Persian footer: حمایت instead of اعانه

### DIFF
--- a/_data/lang/fa.yml
+++ b/_data/lang/fa.yml
@@ -16,7 +16,7 @@ fa:
   subscribe_to_feed: مشترک شدن در خوراک ما
 
   references: مراجع
-  donate: اعانه
+  donate: حمایت
   imprint: اطلاعات حقوقی
   privacy: سیاست محرمانگی
   language: زبان

--- a/fa/donate.md
+++ b/fa/donate.md
@@ -1,16 +1,16 @@
 ---
-title: اعانه
+title: حمایت
 lang: fa
 ---
 
-# اهدای پول
+# حمایت
 
-اعانه شما به شکل‌گیری آینده آزاد و متن‌باز ارتباطات خصوصی نامتمرکز
+حمایت شما به شکل‌گیری آینده آزاد و متن‌باز ارتباطات خصوصی نامتمرکز
 بدون نظارت، تبلیغات یا میلیاردر در میانه کمک می‌کند. 
 
-- اعانه از راه [Liberapay](https://liberapay.com/delta.chat/)
+- حمایت از راه [Liberapay](https://liberapay.com/delta.chat/)
 
-- اعانه از راه [Delta Chat Open Collective](https://opencollective.com/delta-chat/donate)
+- حمایت از راه [Delta Chat Open Collective](https://opencollective.com/delta-chat/donate)
 
 - بیت‌کوین بفرستید به [bc1q8jyzyq9vfhzywvz3sgjx8qvfu88wuxmltg34tk](bitcoin:bc1q8jyzyq9vfhzywvz3sgjx8qvfu88wuxmltg34tk)
 

--- a/fa/references.md
+++ b/fa/references.md
@@ -1,9 +1,9 @@
 ---
-title: مرجع‌ها
+title: مراجع
 lang: fa
 ---
 
-# مرجع‌ها
+# مراجع
 
 > This list is not updated frequently.
 > You can find many more recent references and real-time streamed user voices on [the Fediverse](https://chaos.social/tags/deltachat).


### PR DESCRIPTION
### Problem
On https://delta.chat/fa the footer donate label was «اعانه», which is awkward/wrong in this context, and it was out of sync with the donate page heading («اهدای پول»). References also used «مرجع‌ها» on the page vs «مراجع» in the footer.

### Fix
- `donate` menu/footer string: **حمایت**
- Donate page title/heading/body: use **حمایت** consistently
- References page title: **مراجع** (matches footer)

Also updated the same strings on Transifex so the next translation pull stays consistent.