### PR TITLE
Fix footer social icons alignment on RTL pages

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -201,16 +201,25 @@ table {
 }
 
 .socials {
+    /* Brand labels are Latin (RSS/Mastodon); keep icon→label order even on RTL pages */
     display: inline-flex;
+    direction: ltr;
+    unicode-bidi: isolate;
+    justify-content: center;
+    align-items: center;
     gap: 12px;
+    margin-block: 1em;
 
     a {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         gap: 8px;
+        line-height: 1;
 
         img {
+            display: block;
             height: 1em;
+            width: auto;
         }
     }
 }


### PR DESCRIPTION
### Problem
On RTL pages (e.g. https://delta.chat/fa), the footer `.socials` row (RSS / Mastodon) gets flex-reversed, so icon/label order looks wrong.

### Fix
Minimal CSS only (no extra RTL rule soup):
- `direction: ltr` + `unicode-bidi: isolate` on `.socials` (labels are Latin brand names)
- center/align tweaks and a bit of vertical margin so it sits cleanly under the language list

Follows the “less complexity” guidance from #1393 / #1398.