### PR TITLE
Turn unicode comment that broke CI into ASCII

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -201,7 +201,7 @@ table {
 }
 
 .socials {
-    /* Brand labels are Latin (RSS/Mastodon); keep icon→label order even on RTL pages */
+    /* Brand labels are Latin (RSS/Mastodon); keep icon->label order even on RTL pages */
     display: inline-flex;
     direction: ltr;
     unicode-bidi: isolate;


### PR DESCRIPTION
CI is broken since https://github.com/deltachat/deltachat-pages/pull/1404 got merged with ignored CI failure. Probably due to this unicode char in the comment.