### PR TITLE
Add --print-build-logs to "nix build"

### DIFF
--- a/.github/workflows/jekyll-main.yml
+++ b/.github/workflows/jekyll-main.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
       - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
       - name: Build the site with Jekyll
-        run: nix build
+        run: nix build --print-build-logs
 
       - name: Upload
         run: |

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           PR_ID: ${{github.event.pull_request.number}}
       - name: Build the site with Jekyll
-        run: nix build
+        run: nix build --print-build-logs
 
       - name: Upload preview
         run: |


### PR DESCRIPTION
This is needed because previously when a PR https://github.com/deltachat/deltachat-pages/pull/1404 broke CI, CI logs showed this, but the actual error was truncated:
```
       For full logs, run:
         nix log /nix/store/havddjirlixy1nzm5zibw0882r2rxcxl-deltachat-pages.drv
```

It is impossible to get the log file after CI run, so we need to print the whole log to CI output.

See also https://github.com/NixOS/nix/issues/1904 for the related discussion about this flag.